### PR TITLE
fix: replaced PropTypes.element to PropTypes.node

### DIFF
--- a/packages/core/src/lib/components/Area.js
+++ b/packages/core/src/lib/components/Area.js
@@ -61,12 +61,12 @@ Area.propTypes = {
     id: PropTypes.string,
     sortOrder: PropTypes.number,
     component: PropTypes.shape({
-      default: PropTypes.elementType
+      default: PropTypes.nodeType
     })
   })),
   id: PropTypes.string.isRequired,
   noOuter: PropTypes.bool,
-  wrapper: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  wrapper: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   // eslint-disable-next-line react/forbid-prop-types
   wrapperProps: PropTypes.object
 };

--- a/packages/core/src/lib/components/form/Button.js
+++ b/packages/core/src/lib/components/form/Button.js
@@ -40,7 +40,7 @@ Button.propTypes = {
   isLoading: PropTypes.bool,
   onAction: PropTypes.func,
   outline: PropTypes.bool,
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   url: PropTypes.string,
   variant: PropTypes.string
 };

--- a/packages/core/src/lib/components/form/Form.js
+++ b/packages/core/src/lib/components/form/Form.js
@@ -165,7 +165,7 @@ Form.propTypes = {
   action: PropTypes.string.isRequired,
   btnText: PropTypes.string,
   children: PropTypes.oneOfType(
-    [PropTypes.arrayOf(PropTypes.element), PropTypes.element]
+    [PropTypes.arrayOf(PropTypes.node), PropTypes.node]
   ).isRequired,
   id: PropTypes.string.isRequired,
   method: PropTypes.string.isRequired,

--- a/packages/core/src/lib/components/form/fields/Input.js
+++ b/packages/core/src/lib/components/form/fields/Input.js
@@ -61,7 +61,7 @@ Input.propTypes = {
   instruction: PropTypes.string,
   label: PropTypes.string,
   name: PropTypes.string,
-  prefix: PropTypes.element,
+  prefix: PropTypes.node,
   suffix: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };

--- a/packages/core/src/lib/components/locale/CountryOption.js
+++ b/packages/core/src/lib/components/locale/CountryOption.js
@@ -267,7 +267,7 @@ function CountryOptions(props) {
 }
 
 CountryOptions.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   countries: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/packages/core/src/lib/components/locale/CurrencyOption.js
+++ b/packages/core/src/lib/components/locale/CurrencyOption.js
@@ -186,7 +186,7 @@ function CurrencyOptions(props) {
 }
 
 CurrencyOptions.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   currencies: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/packages/core/src/lib/components/locale/LanguageOption.js
+++ b/packages/core/src/lib/components/locale/LanguageOption.js
@@ -202,7 +202,7 @@ function LanguageOptions(props) {
 }
 
 LanguageOptions.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   languages: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/packages/core/src/lib/components/locale/ProvinceOption.js
+++ b/packages/core/src/lib/components/locale/ProvinceOption.js
@@ -3543,7 +3543,7 @@ function ProvinceOptions(props) {
 }
 
 ProvinceOptions.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   country: PropTypes.string.isRequired
 };
 

--- a/packages/core/src/lib/components/locale/TimezoneOption.js
+++ b/packages/core/src/lib/components/locale/TimezoneOption.js
@@ -450,7 +450,7 @@ function TimezoneOptions(props) {
 }
 
 TimezoneOptions.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   timezones: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 

--- a/packages/core/src/modules/cms/components/admin/NavigationItem.js
+++ b/packages/core/src/modules/cms/components/admin/NavigationItem.js
@@ -32,7 +32,7 @@ export default function NavigationItem({ Icon, url, title }) {
 }
 
 NavigationItem.propTypes = {
-  Icon: PropTypes.elementType.isRequired,
+  Icon: PropTypes.nodeType.isRequired,
   title: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #97 


## What is the new behavior?

In order to avoid errors like Invalid prop children of type array supplied to Component, expected a single ReactElement replaced `PropTypes.element` with `PropTypes.node`. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


