### PR TITLE
fix: setup text to Postgres to avoid confusion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Background (please complete the following information):**
  - NodeJS Version
- - MySQL Version
+ - Postgres Version
  - EverShop Version
  - OS: [e.g. Window, Ubuntu, Mac-OS]
  - Browser [e.g. Chrome, Safari]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ To develop locally:
    ```
    npm install
    ```
-4. Create a MySQL database:
+4. Create a Postgres database:
    ```
-   // EverShop use MySQL for database storeage
+   // EverShop use Postgres for database storage
    ```
 5. Run installation command to create a database schema:
    ```
@@ -77,10 +77,10 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
   - What EverShop version you are using
   - What NodeJs version you are using
   - What OS system you are using
-  - What MySQL version you are using
+  - What Postgres version you are using
 - Steps to reproduce
   - Be specific!
-  - Give sample code if you canwith a 
+  - Give sample code if you can
 - What you expected would happen
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evershop",
   "version": "1.0.0-beta",
-  "description": "A shopping cart platform with Express, React and MySQL",
+  "description": "A shopping cart platform with Express, React and Postgres",
   "files": [
     "bin",
     "src",

--- a/packages/evershop/bin/install/index.js
+++ b/packages/evershop/bin/install/index.js
@@ -50,25 +50,25 @@ async function install() {
     {
       type: 'input',
       name: 'databaseHost',
-      message: 'MySql Database Host (localhost)',
+      message: 'Postgres Database Host (localhost)',
       initial: 'localhost'
     },
     {
       type: 'input',
       name: 'databasePort',
-      message: 'MySql Database Port (5432)',
+      message: 'Postgres Database Port (5432)',
       initial: 5432
     },
     {
       type: 'input',
       name: 'databaseName',
-      message: 'MySql Database Name (evershop)',
+      message: 'Postgres Database Name (evershop)',
       initial: 'evershop'
     },
     {
       type: 'input',
       name: 'databaseUser',
-      message: 'MySql Database User (postgres)',
+      message: 'Postgres Database User (postgres)',
       initial: 'postgres'
     },
     {

--- a/packages/evershop/src/modules/cms/pages/frontStore/homepage/meta.js
+++ b/packages/evershop/src/modules/cms/pages/frontStore/homepage/meta.js
@@ -9,7 +9,7 @@ module.exports = async (request, response, delegate, next) => {
     title: await getSetting('storeName', 'EverShop'),
     description: await getSetting(
       'storeDescription',
-      'An e-commerce platform with Node and MySQL'
+      'An e-commerce platform with Node and Postgres'
     ),
     url: buildUrl('homepage')
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When create new app using
```bash
npx create-evershop-app my-app
```
or run
```bash
npm run setup
```
User will be given a prompt to enter their MySQL info. The code for setup is currently using Postgres, so this should be changed to avoid confusion.

Issue Number: #275 


## What is the new behavior?
No new behavior

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
No breaking change, not that any  I'm aware of

## Other information

Fixed image:
![image](https://github.com/evershopcommerce/evershop/assets/46006210/fa145756-6794-40ef-ad13-c5856b4f095b)

Test result:
![image](https://github.com/evershopcommerce/evershop/assets/46006210/18cd440a-bc3b-425f-a0ad-e2b4fac504c4)
