### PR TITLE
Fix overflow of variants in productView/Variants.jsx

### DIFF
--- a/packages/evershop/src/modules/catalog/pages/frontStore/productView/Variants.jsx
+++ b/packages/evershop/src/modules/catalog/pages/frontStore/productView/Variants.jsx
@@ -111,11 +111,11 @@ export default function Variants({
             <div className="mb-05 text-textSubdued uppercase">
               <span>{a.attribute_name}</span>
             </div>
-            <ul className="variant-option-list flex justify-start">
+            <ul className="variant-option-list flex justify-start gap-05 flex-wrap">
               {options.map((o) => {
-                let className = 'mr-05';
+                className = ''
                 if (a.selected && a.selectedOption === o.optionId) {
-                  className = 'selected mr-05';
+                  className = 'selected';
                 }
                 return (
                   <li key={o.optionId} className={className}>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If a product has too many variants, it overflows the page

![image](https://github.com/evershopcommerce/evershop/assets/1147328/15c9c455-c620-4417-bbfa-e30837f7d6f0)


Issue Number: N/A


## What is the new behavior?
![image](https://github.com/evershopcommerce/evershop/assets/1147328/372eca82-4272-421f-a37a-a2e10fcd4428)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Use `flex-wrap` to wrap variants and `gap` to keep consistent gap between rows and columns