### PR TITLE
Update bootstrap.js

### DIFF
--- a/packages/evershop/src/modules/cms/bootstrap.js
+++ b/packages/evershop/src/modules/cms/bootstrap.js
@@ -14,7 +14,7 @@ module.exports = () => {
       scripts: [],
       bases: []
     },
-    copyright: `© 2022 Evershop. All Rights Reserved.`
+    copyRight: `© 2022 Evershop. All Rights Reserved.`
   };
   config.util.setModuleDefaults('themeConfig', themeConfig);
 };


### PR DESCRIPTION
fix a typo for copyRight text

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #366 


## What is the new behavior?

The default copyright text is now displayed when there is no copyRight property inside configuration file.
{
  "themeConfig": {
      "logo": {
            "alt": "You amazing shop logo",
            "src": "/logo.png",
            "width": 100,
            "height": 100
        },
        "headTags": {
            "links": [],
            "metas": [],
            "scripts": []
        },
        "copyRight": "© 2022 Evershop. All Rights Reserved." --> this will take over the bootstrap.js
    }
}
so the copyRight of defaultProperties inside Footer.jsx never gets used, because there is a graphQL query will update
it with data from configuration, if the data does not exist, the Footer will get a null value from function parameter.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Please also change the documentation of configuration section
It contains a lower case copyright in the sample documentation, change it to copyRight to make it consistent.