### PR TITLE
Fixes a quotation bug in the german catalog.csv

### DIFF
--- a/translations/de/catalog.csv
+++ b/translations/de/catalog.csv
@@ -3,4 +3,4 @@ SHOP BY, Einkaufen nach
 Sort By, Sortieren nach
 There is no product to display, Es gibt keine Produkte zum Anzeigen
 ${count} products, ${count} Produkte
-Search results for "${keyword}", Suchergebnisse für "${keyword}"
+Search results for "${keyword}", Suchergebnisse für \"${keyword}\"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The german `catalog.csv` has a quotation bug in the label `Search results for "${keyword}"` which breaks the build process.

## What is the new behavior?
The double quotes around `${keyword}` are escaped properly now

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No