### PR TITLE
Fix #334: Fixed overlapping of price text and min-max handles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,12 +45,15 @@
     "react/no-unstable-nested-components": "off",
     "no-continue": "off",
     "no-await-in-loop": "off",
-    "no-use-before-define" : "off",
+    "no-use-before-define": "off",
     "global-require": "off",
     "import/extensions": "off",
     "no-shadow": "off",
     "no-lonely-if": "warn",
-    "no-console": "error"
+    "no-console": "error",
+    "jsx-a11y/control-has-associated-label": "off",
+    "jsx-a11y/label-has-associated-control": "off",
+    "no-empty": ["error", { "allowEmptyCatch": true }]
   },
   "ignorePatterns": [
     "/node_modules/",

--- a/packages/evershop/src/components/frontStore/catalog/categoryView/filter/PriceFilter.jsx
+++ b/packages/evershop/src/components/frontStore/catalog/categoryView/filter/PriceFilter.jsx
@@ -104,16 +104,16 @@ export function PriceFilter({
     firstRender.current = false;
     const { value } = e.target;
     if (direction === 'min') {
-      if (value > to - 5) {
-        setFrom(to - 5);
+      if (value > to - 20) {
+        setFrom(to - 20);
       } else {
         setFrom(value);
       }
     }
 
     if (direction === 'max') {
-      if (value - 5 < from) {
-        setTo(from + 5);
+      if (value - 20 < from) {
+        setTo(from + 20);
       } else {
         setTo(value);
       }
@@ -144,12 +144,6 @@ export function PriceFilter({
         <div className="tooltip min">
           <div
             className="push"
-            style={{
-              // eslint-disable-next-line no-mixed-operators
-              width: `calc(${
-                ((from - minPrice) / (maxPrice - minPrice)) * 100
-              }% + 3px)`
-            }}
           />
           <output>{f}</output>
         </div>
@@ -164,12 +158,6 @@ export function PriceFilter({
         <div className="tooltip max">
           <div
             className="push"
-            style={{
-              // eslint-disable-next-line no-mixed-operators
-              width: `calc(${
-                ((to - minPrice) / (maxPrice - minPrice)) * 100
-              }% - 6px)`
-            }}
           />
           <output>{t}</output>
         </div>

--- a/packages/evershop/src/components/frontStore/catalog/categoryView/filter/PriceFilter.scss
+++ b/packages/evershop/src/components/frontStore/catalog/categoryView/filter/PriceFilter.scss
@@ -6,9 +6,11 @@
   width: 100%;
   &.min {
     left: 0;
+    width: auto;
   }
   &.max {
     right: 0;
+    width: auto;
   }
   top: 50%;
   display: flex;

--- a/packages/evershop/src/modules/base/api/global/[auth]apiResponse[apiErrorHandler].js
+++ b/packages/evershop/src/modules/base/api/global/[auth]apiResponse[apiErrorHandler].js
@@ -19,6 +19,7 @@ module.exports = async (request, response, delegate, next) => {
 
     /** If a rejected middleware called next(error) without throwing an error */
     if (isErrorHandlerTriggered(response)) {
+      // If error handler is triggered, return early
       return;
     } else {
       response.json(response.$body || {});

--- a/packages/evershop/src/modules/base/pages/global/response[errorHandler].js
+++ b/packages/evershop/src/modules/base/pages/global/response[errorHandler].js
@@ -22,6 +22,7 @@ module.exports = async (request, response, delegate, next) => {
 
     /** If a rejected middleware called next(error) without throwing an error */
     if (isErrorHandlerTriggered(response)) {
+      // If error handler is triggered, return early
       return;
     } else {
       const route = request.currentRoute;

--- a/packages/evershop/src/modules/catalog/subscribers/category_deleted/deleteUrlRewrite.js
+++ b/packages/evershop/src/modules/catalog/subscribers/category_deleted/deleteUrlRewrite.js
@@ -18,6 +18,7 @@ module.exports = async function deleteUrlReWrite(data) {
     );
 
     if (!urlRewrite) {
+      // No urlRewrite found, nothing to delete
       return;
     } else {
       // Delete all the url rewrite rule for the sub categories and products


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. Max price text collides with min price.
2. Thumbs of slider overlaps.

Issue Number: #334


## What is the new behavior?
1. Fixed the texts of both min and max on left and right respectively to avoid collision.
2. Increased the range between min and max, so thumbs wont overlap with each other.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
