### PR TITLE
Issue #547: Category scrolling in mobile view

### DIFF
--- a/packages/evershop/src/components/frontStore/catalog/categoryView/filter/CategoryFilter.jsx
+++ b/packages/evershop/src/components/frontStore/catalog/categoryView/filter/CategoryFilter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './CategoryFilter.scss';
 import { _ } from '@evershop/evershop/src/lib/locale/translate';
 
 export function CategoryFilter({ currentFilters, categories, updateFilter }) {

--- a/packages/evershop/src/components/frontStore/catalog/categoryView/filter/CategoryFilter.scss
+++ b/packages/evershop/src/components/frontStore/catalog/categoryView/filter/CategoryFilter.scss
@@ -1,0 +1,5 @@
+@media (max-width: 639px) {
+    .category-filter {
+        padding-bottom: 2.5rem;
+    }
+}

--- a/packages/evershop/src/modules/catalog/pages/frontStore/categoryView/Filter.scss
+++ b/packages/evershop/src/modules/catalog/pages/frontStore/categoryView/Filter.scss
@@ -132,6 +132,7 @@ input[type='range']:nth-child(1)::-webkit-slider-thumb {
     background-color: #fff;
     padding: 20px;
     box-sizing: border-box;
+    overflow: auto;
   }
 
   .filter-opener,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In the mobile view, when the categories are going out of screen in the filter view. It is not scrollable and categories out of screen are hidden.

Issue Number: #547 

## What is the new behavior?
The filter view in mobile screen is now scrollable. If the categories go out of screen, it becomes scrollable and none of the categories will be hidden.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Added padding in the category filter for mobile view, so that the filter button does not overlap the checkbox of the last category.
