### PR TITLE
Handle limits if it is not a category in a subpage

### DIFF
--- a/packages/evershop/src/lib/util/defaultPaginationFilters.js
+++ b/packages/evershop/src/lib/util/defaultPaginationFilters.js
@@ -78,19 +78,29 @@ const defaultPaginationFilters = [
     operation: ['eq'],
     callback: (query, operation, value, currentFilters) => {
       const page = currentFilters.find((f) => f.key === 'page') || { value: 1 };
-      const limit = currentFilters.find((f) => f.key === 'limit') || {
-        value: CONSTANTS.ADMIN_COLLECTION_SIZE
-      };
       currentFilters.push({
         key: 'page',
         operation: 'eq',
         value: page.value
       });
-      currentFilters.push({
-        key: 'limit',
-        operation: 'eq',
-        value: limit.value
-      });
+      let limit = { value: Number.MAX_SAFE_INTEGER };
+
+      // eslint-disable-next-line no-underscore-dangle
+      const isCategory = query?._table === 'category';
+      const hasParent = currentFilters.some(item => item.key === 'parent');
+      const doNotSetLimit = isCategory && hasParent;
+      
+      if(!doNotSetLimit) {
+        limit = currentFilters.find((f) => f.key === 'limit') || {
+          value: CONSTANTS.ADMIN_COLLECTION_SIZE
+        };
+        currentFilters.push({
+          key: 'limit',
+          operation: 'eq',
+          value: limit.value
+        });
+      }
+     
       query.limit(
         (parseInt(page.value, 10) - 1) * parseInt(limit.value, 10),
         parseInt(limit.value, 10)


### PR DESCRIPTION
Remove any default limits for categories if its displayed on any other page where parent is present.
Bug : https://github.com/evershopcommerce/evershop/issues/630

https://github.com/user-attachments/assets/4ad4f2c0-d9a5-480e-83cd-79c35c1460e5


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
