### PR TITLE
fix: treat HEAD requests like GET routes

### DIFF
--- a/packages/evershop/src/bin/lib/addDefaultMiddlewareFuncs.ts
+++ b/packages/evershop/src/bin/lib/addDefaultMiddlewareFuncs.ts
@@ -29,6 +29,13 @@ import {
 } from '../../modules/setting/services/setting.js';
 import { getDevMiddleware, getHotMiddleware } from './devEnvHelper.js';
 
+function routeSupportsMethod(route, method) {
+  return (
+    route.method.includes(method) ||
+    (method === 'HEAD' && route.method.includes('GET'))
+  );
+}
+
 export function addDefaultMiddlewareFuncs(app) {
   app.use((request, response, next) => {
     response.debugMiddlewares = [];
@@ -190,7 +197,7 @@ export function addDefaultMiddlewareFuncs(app) {
     const matchedRoutes = routes.filter((r) => {
       const regexp = pathToRegexp(r.path, []);
       const match = regexp.exec(requestPath);
-      if (match && r.method.includes(method)) {
+      if (match && routeSupportsMethod(r, method)) {
         return true;
       } else {
         return false;
@@ -265,7 +272,7 @@ export function addDefaultMiddlewareFuncs(app) {
       // Get the current http method
       const method = request.method.toUpperCase();
       // Check if the route supports the current http method
-      if (route && route.method.includes(method)) {
+      if (route && routeSupportsMethod(route, method)) {
         request.currentRoute = route;
       }
       return next();

--- a/packages/evershop/src/lib/middleware/tests/unit/handlers.middleware.test.js
+++ b/packages/evershop/src/lib/middleware/tests/unit/handlers.middleware.test.js
@@ -47,6 +47,19 @@ describe('test middleware', () => {
     expect(loadProduct).toHaveBeenCalledTimes(2);
   });
 
+  it('It should match HEAD requests against GET routes', async () => {
+    const response = await axios.head(`http://localhost:${port}/middleware`, {
+      validateStatus(status) {
+        return status >= 200 && status <= 500;
+      }
+    });
+    expect(response.status).toEqual(500);
+    expect(loadProductAttribute).toHaveBeenCalledTimes(3);
+    expect(loadProductImage).toHaveBeenCalledTimes(3);
+    expect(loadCategory).toHaveBeenCalledTimes(3);
+    expect(loadProduct).toHaveBeenCalledTimes(3);
+  });
+
   it('It should not execute the middleware functions after error occurred', async () => {
     expect(loadProductOption).toHaveBeenCalledTimes(0);
   });


### PR DESCRIPTION
## Summary
- treat `HEAD` requests as matching `GET` routes during route resolution
- apply the same fallback when resolving rewritten routes
- add a middleware regression test covering the `HEAD` -> `GET` behavior

## Validation
- `npm run compile:db`
- `npm run compile`
- `npm test -- packages/evershop/dist/lib/middleware/tests/unit/handlers.middleware.test.js`