### PR TITLE
fix(ssr): return 500 on render error instead of hanging; partial data…

### DIFF
--- a/packages/evershop/src/lib/response/render.ts
+++ b/packages/evershop/src/lib/response/render.ts
@@ -117,7 +117,7 @@ function renderDevelopment(
   `);
 }
 
-function renderProduction(request, response) {
+function renderProduction(request, response, next?) {
   const route = request.currentRoute;
   const serverIndexPath = path.resolve(
     getRouteBuildPath(route),
@@ -165,12 +165,19 @@ function renderProduction(request, response) {
     })
     .catch((e) => {
       error(e);
+      // This render runs inside a floated promise, so a throw here never reaches
+      // the calling middleware's try/catch. Without forwarding it, the request
+      // hangs until the socket/requestTimeout fires (no status, no body). Hand it
+      // to the error handler so the client gets a proper 500 instead.
+      if (typeof next === 'function' && !response.headersSent) {
+        next(e);
+      }
     });
 }
 
-export function render(request, response) {
+export function render(request, response, next?) {
   if (isProductionMode()) {
-    renderProduction(request, response);
+    renderProduction(request, response, next);
   } else {
     renderDevelopment(request, response);
   }

--- a/packages/evershop/src/modules/base/pages/global/response[errorHandler].ts
+++ b/packages/evershop/src/modules/base/pages/global/response[errorHandler].ts
@@ -119,7 +119,7 @@ export default async (request: EvershopRequest, response, next) => {
             } as AppStateContextValue
           });
         } else {
-          render(request, response);
+          render(request, response, next);
         }
       }
     }

--- a/packages/evershop/src/modules/graphql/pages/global/[buildQuery]graphql[response].js
+++ b/packages/evershop/src/modules/graphql/pages/global/[buildQuery]graphql[response].js
@@ -73,17 +73,23 @@ export default async function graphql(request, response, next) {
             document,
             variableValues: graphqlVariables
           });
+          // Render with whatever data resolved instead of aborting the whole
+          // page on the first field error. A single failing or non-critical
+          // resolver (e.g. "related products") should degrade that area, not
+          // turn the entire SSR response into a 500. Field errors are logged;
+          // partial `data.data` (or {} on total failure) is passed through.
           if (data.errors) {
-            next(data.errors[0]);
-          } else {
-            response.locals = response.locals || {};
-            response.locals.graphqlResponse = JSON.parse(
-              JSON.stringify(data.data)
+            data.errors.forEach((e) =>
+              debug(`GraphQL field error: ${e.message}`)
             );
-            // Get id and props from the queryRaw object and assign to response.locals.propsMap
-            response.locals.propsMap = propsMap;
-            next();
           }
+          response.locals = response.locals || {};
+          response.locals.graphqlResponse = data.data
+            ? JSON.parse(JSON.stringify(data.data))
+            : {};
+          // Get id and props from the queryRaw object and assign to response.locals.propsMap
+          response.locals.propsMap = propsMap;
+          next();
         }
       }
     }


### PR DESCRIPTION
… on field error

- renderProduction runs inside a floated promise, so a throw never reached the calling middleware's try/catch and the request hung until requestTimeout fired (no status, no body). Thread `next` through render/renderProduction and forward render-time errors to the error handler so the client gets a proper 500.
- A single failing or non-critical GraphQL field aborted the whole SSR page with a 500. Log field errors and render with whatever data resolved (partial, or {}) instead of discarding it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
