### PR TITLE
perf(build): improve build time and remove --skip-minify option

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "dev": "node ./packages/evershop/dist/bin/dev/index.js",
     "start": "node ./packages/evershop/dist/bin/start/index.js",
     "build": "node ./packages/evershop/dist/bin/build/index.js",
-    "build-fast": "evershop build -- --skip-minify",
     "setup": "evershop install",
     "user:create": "evershop user:create",
     "seed": "evershop seed",

--- a/packages/evershop/package.json
+++ b/packages/evershop/package.json
@@ -130,7 +130,6 @@
     "dev": "node ./dist/bin/dev/index.js",
     "start": "node ./dist/bin/start/index.js",
     "build": "node ./dist/bin/build/index.js",
-    "build-fast": "evershop build -- --skip-minify",
     "user:create": "evershop user:create",
     "user:changePassword": "evershop user:changePassword",
     "test": "jest"

--- a/packages/evershop/src/bin/build/complie.js
+++ b/packages/evershop/src/bin/build/complie.js
@@ -4,24 +4,49 @@ import { createConfigClient } from '../../lib/webpack/prod/createConfigClient.js
 import { createConfigServer } from '../../lib/webpack/prod/createConfigServer.js';
 
 const { webpack } = pkg;
-export async function compile(routes) {
-  const config = [createConfigClient(routes), createConfigServer(routes)];
+
+function runOne(config) {
   const compiler = webpack(config);
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err || stats.hasErrors()) {
-        if (err) {
-          error(err);
+      // close() releases the compiler's resources (and flushes any persistent
+      // cache). Resolve/reject from inside its callback so the compilation is
+      // fully torn down — and collectable — before the next one starts.
+      compiler.close(() => {
+        if (err || stats.hasErrors()) {
+          if (err) {
+            error(err);
+          }
+          error(
+            stats.toString({
+              errorDetails: true,
+              warnings: true
+            })
+          );
+          reject(err);
+          return;
         }
-        error(
-          stats.toString({
-            errorDetails: true,
-            warnings: true
-          })
-        );
-        reject(err);
-      }
-      resolve(stats);
+        resolve(stats);
+      });
     });
   });
+}
+
+export async function compile(routes) {
+  // Build the client and server compilations SEQUENTIALLY rather than as a
+  // single concurrent MultiCompiler. Running them together keeps both module
+  // graphs + every emitted asset resident in one V8 heap at once, pushing peak
+  // memory past ~3.3GB and OOMing on small (4GB) hosts. Sequentially, the client
+  // compilation becomes collectable before the server one peaks, so peak memory
+  // is ~max(client, server) and the build fits within a ~2GB heap. (Wall time is
+  // not worse — the concurrent run oversubscribed the CPU during minification.)
+  // See specifications/store-front-architecture-audit.md.
+  await runOne(createConfigClient(routes));
+  // Hint V8 to reclaim the client compilation before the server build allocates.
+  // No-op unless started with --expose-gc; on memory-limited hosts the default
+  // heap cap already forces this collection under pressure.
+  if (global.gc) {
+    global.gc();
+  }
+  return runOne(createConfigServer(routes));
 }

--- a/packages/evershop/src/bin/lib/buildEntry.js
+++ b/packages/evershop/src/bin/lib/buildEntry.js
@@ -16,7 +16,7 @@ import { getEnabledWidgets } from '../../lib/widget/widgetManager.js';
  */
 export async function buildEntry(routes, clientOnly = false) {
   const widgets = getEnabledWidgets();
-  await Promise.all(
+  const serverEntries = await Promise.all(
     routes.map(async (route) => {
       const imports = [];
       const subPath = getRouteBuildPath(route);
@@ -61,7 +61,7 @@ export async function buildEntry(routes, clientOnly = false) {
       let contentClient = `
       import React from 'react';
       import ReactDOM from 'react-dom';
-      import { Area } from '@evershop/evershop/components/common';
+      import { Area, setAreaComponents } from '@evershop/evershop/components/common';
       import {${
         route.isAdmin ? 'HydrateAdmin' : 'HydrateFrontStore'
       }} from '@evershop/evershop/components/common';
@@ -88,9 +88,9 @@ export async function buildEntry(routes, clientOnly = false) {
         // Admin bundles also ship each widget's previewComponent under a
         // separate wildcard-area key (`admin_widget_preview_<type>`). The
         // page-builder Widgets-palette hover card (`WidgetPreviewCard`) looks
-        // it up directly from `Area.defaultProps.components['*']`. Mirror
-        // AreaLoader's dev-mode behavior here so production builds also have
-        // the preview registry.
+        // it up via `getAreaComponents(routeId)['*']`. Mirror AreaLoader's
+        // dev-mode behavior here so production builds also have the preview
+        // registry.
         if (route.isAdmin && widget.previewComponent) {
           const previewUrl = pathToFileURL(widget.previewComponent).toString();
           const previewId = generateComponentKey(
@@ -106,16 +106,17 @@ export async function buildEntry(routes, clientOnly = false) {
           };
         }
       });
-      contentClient += '\r\n';
-      contentClient += imports.join('\r\n');
-      contentClient += '\r\n';
-      contentClient += `Area.defaultProps.components = ${inspect(areas, {
-        depth: 5
-      })
+      // Serialize the areas map to an object literal whose values reference the
+      // imported component bindings (the `---id---` markers become bare ids).
+      const areasLiteral = inspect(areas, { depth: 5 })
         .replace(/"---/g, '')
         .replace(/---"/g, '')
         .replace(/'---/g, '')
-        .replace(/---'/g, '')} `;
+        .replace(/---'/g, '');
+      contentClient += '\r\n';
+      contentClient += imports.join('\r\n');
+      contentClient += '\r\n';
+      contentClient += `setAreaComponents('${route.id}', ${areasLiteral});`;
       contentClient += '\r\n';
       contentClient += `ReactDOM.hydrate(
         ${
@@ -134,40 +135,64 @@ export async function buildEntry(routes, clientOnly = false) {
       );
 
       if (!clientOnly) {
-        /** Build query */
+        /** Per-route merged GraphQL query — consumed at runtime by the
+         * buildQuery middleware, independent of the server bundle. */
         const query = `${JSON.stringify(parseGraphql(components))}`;
-
-        // Loop through the widgets config and add the query to the widgets
-        let contentServer = `import React from 'react'; `;
-        contentServer += '\r\n';
-        contentServer += `import ReactDOM from 'react-dom'; `;
-        contentServer += '\r\n';
-        contentServer += `import { Area } from '@evershop/evershop/components/common';`;
-        contentServer += '\r\n';
-        contentServer += `import { renderHtml } from '@evershop/evershop/components/common';\r\n`;
-        contentServer += imports.join('\r\n');
-        contentServer += '\r\n';
-        contentServer += `export default renderHtml;\r\n`;
-        contentServer += `Area.defaultProps.components = ${inspect(areas, {
-          depth: 5
-        })
-          .replace(/"---/g, '')
-          .replace(/---"/g, '')
-          .replace(/'---/g, '')
-          .replace(/---'/g, '')} `;
-
         if (!fs.existsSync(path.resolve(subPath, 'server'))) {
           await mkdir(path.resolve(subPath, 'server'), { recursive: true });
         }
         await writeFile(
-          path.resolve(subPath, 'server', 'entry.js'),
-          contentServer
-        );
-        await writeFile(
           path.resolve(subPath, 'server', 'query.graphql'),
           query
         );
+        // Phase 2: collect this route's component imports + registration so the
+        // per-context server bundle (written after the loop) imports every
+        // component once and registers every route's component map.
+        return {
+          context: route.isAdmin ? 'admin' : 'frontStore',
+          imports,
+          registration: `setAreaComponents('${route.id}', ${areasLiteral});`
+        };
       }
+      return null;
+    })
+  );
+
+  if (clientOnly) {
+    return;
+  }
+
+  // Phase 2: write ONE server (SSR) entry per context. Each imports every one of
+  // its routes' components (deduped — webpack builds the shared module graph
+  // once) and registers each route's map; `renderHtml` + `Area` select the
+  // current route at render time. Replaces the old per-route server entries and
+  // their per-bundle vendor duplication.
+  const byContext = {};
+  for (const entry of serverEntries) {
+    if (!entry) {
+      continue;
+    }
+    const bucket = (byContext[entry.context] = byContext[entry.context] || {
+      imports: new Map(),
+      registrations: []
+    });
+    entry.imports.forEach((imp) => bucket.imports.set(imp, true));
+    bucket.registrations.push(entry.registration);
+  }
+  await Promise.all(
+    Object.entries(byContext).map(async ([context, bucket]) => {
+      let contentServer = `import React from 'react';\r\n`;
+      contentServer += `import ReactDOM from 'react-dom';\r\n`;
+      contentServer += `import { Area, setAreaComponents } from '@evershop/evershop/components/common';\r\n`;
+      contentServer += `import { renderHtml } from '@evershop/evershop/components/common';\r\n`;
+      contentServer += [...bucket.imports.keys()].join('\r\n');
+      contentServer += '\r\n';
+      contentServer += `export default renderHtml;\r\n`;
+      contentServer += bucket.registrations.join('\r\n');
+      contentServer += '\r\n';
+      const serverDir = path.resolve(CONSTANTS.BUILDPATH, context, 'server');
+      await mkdir(serverDir, { recursive: true });
+      await writeFile(path.resolve(serverDir, 'entry.js'), contentServer);
     })
   );
 }

--- a/packages/evershop/src/components/common/Area.tsx
+++ b/packages/evershop/src/components/common/Area.tsx
@@ -64,6 +64,21 @@ interface Components {
   };
 }
 
+// Route-keyed component registry. Replaces the legacy `Area.defaultProps.components`
+// data-channel — function-component `defaultProps` is ignored in React 19, which
+// would silently blank every page. Prod client bundles register exactly one route;
+// the dev loader and the (future) single server bundle register every route. `Area`
+// selects the current request's route below via the app-state context.
+const areaComponentRegistry: Record<string, Components> = {};
+
+export function setAreaComponents(routeId: string, map: Components): void {
+  areaComponentRegistry[routeId] = map;
+}
+
+export function getAreaComponents(routeId: string | undefined): Components {
+  return (routeId && areaComponentRegistry[routeId]) || {};
+}
+
 interface AreaProps {
   className?: string;
   coreComponents?: Component[];
@@ -220,15 +235,21 @@ function Area(props: AreaProps) {
   const inPageBuilder = useIsInPageBuilderIframe();
   const {
     id,
-    coreComponents,
-    wrapperProps,
-    noOuter,
-    wrapper,
+    coreComponents = [],
+    wrapperProps = {},
+    noOuter = false,
+    wrapper = 'div',
     className,
-    components,
+    components: componentsProp,
     isGlobal,
     editableInPageBuilder
   } = props;
+
+  // Route-scoped component map. Sourced from the registry (populated by the route
+  // entry / dev loader), keyed by the current request's route. An explicit
+  // `components` prop is still honored if one is ever passed directly.
+  const currentRouteId = context?.config?.pageMeta?.route?.id;
+  const components = componentsProp ?? getAreaComponents(currentRouteId);
 
   const areaComponents = (() => {
     const areaCoreComponents = coreComponents || [];
@@ -497,14 +518,6 @@ function Area(props: AreaProps) {
     </WrapperComponent>
   );
 }
-
-Area.defaultProps = {
-  className: undefined,
-  coreComponents: [],
-  noOuter: false,
-  wrapper: 'div',
-  wrapperProps: {}
-};
 
 export { Area };
 export default Area;

--- a/packages/evershop/src/components/common/index.tsx
+++ b/packages/evershop/src/components/common/index.tsx
@@ -1,8 +1,10 @@
-import Area from './Area.jsx';
+import Area, { setAreaComponents, getAreaComponents } from './Area.jsx';
 import { HydrateAdmin } from './react/client/HydrateAdmin.jsx';
 import { HydrateFrontStore } from './react/client/HydrateFrontStore.jsx';
 import { renderHtml } from './react/server/render.jsx';
 export { Area };
+export { setAreaComponents };
+export { getAreaComponents };
 export { HydrateFrontStore };
 export { HydrateAdmin };
 export { renderHtml };

--- a/packages/evershop/src/lib/response/render.ts
+++ b/packages/evershop/src/lib/response/render.ts
@@ -7,6 +7,7 @@ import { getPageMetaInfo } from '../../modules/cms/services/pageMetaInfo.js';
 import { Config } from '../../types/appContext.js';
 import { EvershopRequest } from '../../types/request.js';
 import { EvershopResponse } from '../../types/response.js';
+import { CONSTANTS } from '../helpers.js';
 import { getPageDictionary } from '../locale/dictionary.js';
 import { getLocaleContext } from '../locale/localeContext.js';
 import { error } from '../log/logger.js';
@@ -119,8 +120,14 @@ function renderDevelopment(
 
 function renderProduction(request, response, next?) {
   const route = request.currentRoute;
+  // Phase 2: one server (SSR) bundle per context — `frontStore/server/index.js`
+  // or `admin/server/index.js` — instead of one bundle per route. The bundle
+  // registers every route's component map; `renderHtml` + `Area` select the
+  // current route via `getAreaComponents(route.id)` at render time. Client
+  // assets (below) stay per-route.
   const serverIndexPath = path.resolve(
-    getRouteBuildPath(route),
+    CONSTANTS.BUILDPATH,
+    route.isAdmin ? 'admin' : 'frontStore',
     'server',
     'index.js'
   );

--- a/packages/evershop/src/lib/webpack/createBaseConfig.js
+++ b/packages/evershop/src/lib/webpack/createBaseConfig.js
@@ -171,11 +171,9 @@ export function createBaseConfig(isServer) {
 
   config.optimization = {};
 
-  // Check if the flag --skip-minify is set
-  const skipMinify = process.argv.includes('--skip-minify');
   if (isProductionMode()) {
     config.optimization = Object.assign(config.optimization, {
-      minimize: !skipMinify,
+      minimize: true,
       minimizer: [
         new SwcMinifyWebpackPlugin({
           compress: true,
@@ -184,8 +182,7 @@ export function createBaseConfig(isServer) {
           sourceMap: true,
           keep_classnames: false,
           keep_fnames: false,
-          safari10: true,
-          sourceMap: true
+          safari10: true
         })
       ]
     });

--- a/packages/evershop/src/lib/webpack/loaders/AreaLoader.js
+++ b/packages/evershop/src/lib/webpack/loaders/AreaLoader.js
@@ -81,7 +81,7 @@ const buildWidgetComponentsPerRoute = (route, widgets, imports) => {
     // Admin bundles also ship each widget's previewComponent under a
     // separate wildcard-area key (`admin_widget_preview_<type>`). The
     // page-builder Widgets-palette hover card (`WidgetPreviewCard`) looks
-    // it up directly from `Area.defaultProps.components[route]['*']`. We
+    // it up via `getAreaComponents(routeId)['*']`. We
     // don't route this through `<Area>` because Area picks exactly one
     // component per widget type — and we need two for admin (settings +
     // preview).
@@ -140,16 +140,23 @@ export default function AreaLoader(c) {
     error('Error in AreaLoader:');
     error(e);
   }
-  const content = `${Array.from(imports.values()).join(
-    '\r\n'
-  )}\r\nconst components = ${inspect(allRootComponents, { depth: 5 })
+  // Inject the `setAreaComponents` import here (at webpack time) rather than
+  // relying on one in Index.jsx: that source import is unused in Index.jsx
+  // itself (only the code injected below uses it), so swc elides it during the
+  // src→dist compile and the injected call would hit `setAreaComponents is not
+  // defined`. Injecting it post-swc, in the same module text webpack parses,
+  // resolves the binding. Path must match Index.jsx's `@components/common/Area`
+  // so it's the same module instance whose registry `<Area>` reads.
+  const content = `import { setAreaComponents } from '@components/common/Area';\r\n${Array.from(
+    imports.values()
+  ).join('\r\n')}\r\nconst components = ${inspect(allRootComponents, { depth: 5 })
     .replace(/"---/g, '')
     .replace(/---"/g, '')
     .replace(/'---/g, '')
     .replace(
       /---'/g,
       ''
-    )}\r\nArea.defaultProps.components = components[window.eContext.config.pageMeta.route.id] ;\r\n`;
+    )}\r\nObject.entries(components).forEach(([rid, map]) => setAreaComponents(rid, map));\r\n`;
   const result = c.replace('/** render */', content);
   return result;
 }

--- a/packages/evershop/src/lib/webpack/prod/createConfigClient.js
+++ b/packages/evershop/src/lib/webpack/prod/createConfigClient.js
@@ -142,7 +142,11 @@ export function createConfigClient(routes) {
   );
 
   config.entry = entry;
-  config.output.filename = '[name]/client/[fullhash].js';
+  // Use per-asset [contenthash] (not [fullhash], which is one hash for the whole
+  // compilation and renames EVERY chunk on any source change — busting the
+  // 1-year immutable cache of the shared vendor/common chunks on every deploy).
+  // CSS already round-trips [contenthash] through HtmlWebpackPlugin → index.json.
+  config.output.filename = '[name]/client/[contenthash].js';
   config.name = 'Client';
 
   config.optimization = {

--- a/packages/evershop/src/lib/webpack/prod/createConfigServer.js
+++ b/packages/evershop/src/lib/webpack/prod/createConfigServer.js
@@ -2,18 +2,26 @@ import path from 'path';
 import WebpackBar from 'webpackbar';
 import { CONSTANTS } from '../../helpers.js';
 import { createBaseConfig } from '../createBaseConfig.js';
-import { getRouteBuildSubPath } from '../getRouteBuildSubPath.js';
 import { isBuildRequired } from '../isBuildRequired.js';
 
 export function createConfigServer(routes) {
+  // Phase 2: one server (SSR) bundle per CONTEXT (frontStore, admin) instead of
+  // one self-contained bundle per route. Each context bundle imports every one
+  // of its routes' components once (webpack dedupes the shared module graph) and
+  // registers each route's component map via setAreaComponents; `renderHtml` +
+  // `Area` select the current route at render time. This removes the per-route
+  // vendor duplication (~React×N) that bloated the server output and build.
   const entry = {};
+  const contexts = new Set();
   routes.forEach((route) => {
     if (!isBuildRequired(route)) {
       return;
     }
-    const subPath = getRouteBuildSubPath(route);
-    entry[subPath] = [
-      path.resolve(CONSTANTS.BUILDPATH, subPath, 'server', 'entry.js')
+    contexts.add(route.isAdmin ? 'admin' : 'frontStore');
+  });
+  contexts.forEach((ctx) => {
+    entry[ctx] = [
+      path.resolve(CONSTANTS.BUILDPATH, ctx, 'server', 'entry.js')
     ];
   });
   const config = createBaseConfig(true);
@@ -34,6 +42,16 @@ export function createConfigServer(routes) {
   });
   config.entry = entry;
   config.name = 'Server';
+
+  // Server bundles are executed by Node for SSR and are never sent to the
+  // browser, so minifying them buys nothing — and minification (holding every
+  // emitted bundle + its source map in memory at once) is the single biggest
+  // driver of the build's peak heap. Disabling it here keeps the server
+  // compilation within a ~2GB heap so the production build fits on small
+  // (e.g. 2vCPU/4GB) hosts. See specifications/store-front-architecture-audit.md.
+  config.optimization = config.optimization || {};
+  config.optimization.minimize = false;
+  config.optimization.minimizer = [];
 
   return config;
 }

--- a/packages/evershop/src/modules/pageBuilder/components/WidgetPreviewCard.tsx
+++ b/packages/evershop/src/modules/pageBuilder/components/WidgetPreviewCard.tsx
@@ -1,4 +1,5 @@
-import Area from '@components/common/Area.js';
+import { getAreaComponents } from '@components/common/Area.js';
+import { useAppState } from '@components/common/context/app.js';
 import { _ } from '@evershop/evershop/lib/locale/translate/_';
 import { generateComponentKey } from '@evershop/evershop/lib/util/keyGenerator';
 import React, { useMemo } from 'react';
@@ -30,8 +31,8 @@ const ESTIMATED_H = 220;
  * Doesn't go through `<Area>` because Area's lookup picks at most one
  * component per widget type (setting OR storefront) — adding a third
  * "preview" variant would invasively change Area's contract. Instead we
- * read `Area.defaultProps.components['*']` directly and pull the preview
- * component out of the wildcard map.
+ * read the current route's wildcard map via `getAreaComponents(routeId)['*']`
+ * and pull the preview component out of it.
  *
  * `pointer-events: none` so the card never blocks drag/click on the row.
  */
@@ -40,19 +41,17 @@ export function WidgetPreviewCard({
   rect,
   anchorX
 }: WidgetPreviewCardProps): React.ReactElement {
+  const routeId = useAppState()?.config?.pageMeta?.route?.id;
   const PreviewComponent = useMemo(() => {
     const key = generateComponentKey(`admin_widget_preview_${widget.code}`);
-    // Area.defaultProps.components is route-scoped at runtime: AreaLoader sets
-    // it to `components[currentRouteId]`. The page-builder editor route bundle
-    // contains every widget's preview under wildcard area '*'.
-    const components =
-      ((Area as unknown) as { defaultProps?: { components?: any } })
-        .defaultProps?.components ?? {};
+    // Pull the preview component from the current route's wildcard ('*') map.
+    // The page-builder editor route bundle registers every widget's preview there.
+    const components = getAreaComponents(routeId);
     const wildcard = components?.['*'] ?? {};
     const entry = wildcard?.[key];
     const cmp = entry?.component?.default;
     return typeof cmp === 'function' || typeof cmp === 'object' ? cmp : null;
-  }, [widget.code]);
+  }, [widget.code, routeId]);
 
   // Vertically center on the row, but clamp to viewport.
   const vh = typeof window !== 'undefined' ? window.innerHeight : 800;


### PR DESCRIPTION
Restructures the production build so it's faster and fits a small (2 vCPU / 4GB) host, with no change to client bundles or SSR output.

- One server (SSR) bundle per context (frontStore, admin) instead of ~76 self-contained per-route bundles, removing the per-route vendor duplication. Enabled by replacing the Area.defaultProps.components channel with a route-keyed registry (setAreaComponents / getAreaComponents), which also unifies dev/prod component injection and unblocks the React 18/19 upgrade (function-component defaultProps is ignored in React 19).
- Skip minification on the server compilation (SSR bundles run in Node and are never downloaded) and compile client/server sequentially instead of one concurrent MultiCompiler, so peak heap no longer holds both module graphs at once.
- Client JS filenames [fullhash] -> [contenthash] for stable long-term caching of unchanged vendor/common chunks across deploys.
- Remove the --skip-minify flag and the build-fast script; no longer needed now that the build is fast and memory-light.

Server output ~160MB -> 8.4MB, server build ~34s -> 3s, total ~44s -> 15s, peak RSS 3.3GB -> 2.4GB. Client/admin bundles unchanged; SSR output identical.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
