### PR TITLE
metafield: trim field types, block-editor rich text, Editor toolbar t…

### DIFF
--- a/packages/evershop/src/components/admin/metafield/DefinitionEditor.tsx
+++ b/packages/evershop/src/components/admin/metafield/DefinitionEditor.tsx
@@ -22,14 +22,14 @@ const TYPE_OPTIONS = [
   { value: 'date', label: _('Date') },
   { value: 'color', label: _('Color') },
   { value: 'url', label: 'URL' },
-  { value: 'money', label: _('Money') },
-  { value: 'json', label: 'JSON' },
-  { value: 'reference', label: _('Reference') },
   { value: 'group', label: _('Group') }
 ];
 
-// Sub-fields are one level deep in the editor (scalars only — no nested groups).
-const SUB_TYPE_OPTIONS = TYPE_OPTIONS.filter((o) => o.value !== 'group');
+// Sub-fields are one level deep, scalar leaves only — no nested groups and no
+// block-editor `rich_text` (which is a single top-level field).
+const SUB_TYPE_OPTIONS = TYPE_OPTIONS.filter(
+  (o) => o.value !== 'group' && o.value !== 'rich_text'
+);
 
 const FORM_ID = 'metafieldDefinitionForm';
 

--- a/packages/evershop/src/components/admin/metafield/MetafieldSection.tsx
+++ b/packages/evershop/src/components/admin/metafield/MetafieldSection.tsx
@@ -37,41 +37,37 @@ interface Props {
   ownerType: string;
   /** Current values (the entity's meta_data) to prefill the form for editing. */
   values?: Record<string, unknown>;
-  /** Store currency (shop.currency) used for `money` fields. */
-  currency?: string;
 }
 
 /** Human-readable preview of a single scalar value, or null when not set. */
 function formatScalar(type: string, value: unknown): string | null {
   if (value === '' || value === undefined || value === null) return null;
   if (type === 'boolean') return value ? _('Yes') : _('No');
-  if (type === 'money') {
-    const v = value as { amount?: unknown; currency?: string };
-    if (
-      v &&
-      typeof v === 'object' &&
-      v.amount !== undefined &&
-      v.amount !== ''
-    ) {
-      return `${v.amount} ${v.currency ?? ''}`.trim();
-    }
-    return null;
-  }
-  if (type === 'reference') {
-    const v = value as { referenceType?: string; id?: unknown };
-    if (v && typeof v === 'object' && v.id !== undefined && v.id !== '') {
-      return `${v.referenceType ?? ''} #${v.id}`.trim();
-    }
-    return null;
-  }
-  if (type === 'json') {
-    return typeof value === 'string' ? value : JSON.stringify(value);
-  }
   return String(value);
+}
+
+/** Plain-text snippet of block-editor content for the collapsed preview row. */
+function richTextPreview(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const parts: string[] = [];
+  for (const row of value as any[]) {
+    for (const col of row?.columns ?? []) {
+      for (const block of col?.data?.blocks ?? []) {
+        if (typeof block?.data?.text === 'string') {
+          parts.push(block.data.text.replace(/<[^>]*>/g, ''));
+        } else if (Array.isArray(block?.data?.items)) {
+          parts.push(block.data.items.map(String).join(', '));
+        }
+      }
+    }
+  }
+  const text = parts.join(' ').replace(/\s+/g, ' ').trim();
+  return text || null;
 }
 
 /** Preview text for a field's current value (lists joined with • ), or null. */
 function formatPreview(def: Definition, value: unknown): string | null {
+  if (def.type === 'rich_text') return richTextPreview(value);
   if (def.type === 'group') {
     if (def.isList) {
       const n = Array.isArray(value)
@@ -110,11 +106,11 @@ function formatPreview(def: Definition, value: unknown): string | null {
  */
 function MetafieldRow({
   def,
-  currency,
+  initialValue,
   onEditDefinition
 }: {
   def: Definition;
-  currency: string;
+  initialValue?: unknown;
   onEditDefinition: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -177,36 +173,48 @@ function MetafieldRow({
         ) : null}
       </div>
       <div className="col-span-2">
-        {!open ? (
-          <button
-            type="button"
-            onClick={() => setOpen(true)}
-            data-testid={`mf-preview-${def.key}`}
-            className="flex w-full items-start justify-between gap-2 rounded-md border border-transparent px-2 py-1.5 text-left hover:border-divider hover:bg-muted/40"
-          >
-            <span
-              className={
-                preview === null
-                  ? 'text-sm italic text-muted-foreground'
-                  : 'line-clamp-2 break-words text-sm'
-              }
-            >
-              {preview === null ? _('Not set') : preview}
-            </span>
-            <Pencil className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          </button>
-        ) : null}
-        <div className={open ? '' : 'hidden'}>
-          <MetafieldValueInput field={def} name={name} currency={currency} />
-          <button
-            type="button"
-            onClick={handleDone}
-            data-testid={`mf-done-${def.key}`}
-            className="mt-2 text-sm text-primary hover:underline"
-          >
-            {_('Done')}
-          </button>
-        </div>
+        {def.type === 'rich_text' ? (
+          // Block editor: render inline (always visible). It must not mount inside
+          // a hidden container, and a one-line preview can't represent it.
+          <MetafieldValueInput
+            field={def}
+            name={name}
+            initialValue={initialValue}
+          />
+        ) : (
+          <>
+            {!open ? (
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                data-testid={`mf-preview-${def.key}`}
+                className="flex w-full items-start justify-between gap-2 rounded-md border border-transparent px-2 py-1.5 text-left hover:border-divider hover:bg-muted/40"
+              >
+                <span
+                  className={
+                    preview === null
+                      ? 'text-sm italic text-muted-foreground'
+                      : 'line-clamp-2 break-words text-sm'
+                  }
+                >
+                  {preview === null ? _('Not set') : preview}
+                </span>
+                <Pencil className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </button>
+            ) : null}
+            <div className={open ? '' : 'hidden'}>
+              <MetafieldValueInput field={def} name={name} />
+              <button
+                type="button"
+                onClick={handleDone}
+                data-testid={`mf-done-${def.key}`}
+                className="mt-2 text-sm text-primary hover:underline"
+              >
+                {_('Done')}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -218,11 +226,7 @@ function MetafieldRow({
  * text, expand to edit) that contributes a `metafields` object to the parent form
  * payload, and offers an "Add field" popup plus a read-only "View JSON".
  */
-export function MetafieldSection({
-  ownerType,
-  values,
-  currency = 'USD'
-}: Props) {
+export function MetafieldSection({ ownerType, values }: Props) {
   const [definitions, setDefinitions] = useState<Definition[]>([]);
   const [loading, setLoading] = useState(true);
   const [addOpen, setAddOpen] = useState(false);
@@ -320,7 +324,11 @@ export function MetafieldSection({
               <MetafieldRow
                 key={`${def.namespace}.${def.key}`}
                 def={def}
-                currency={currency}
+                initialValue={
+                  (values as Record<string, Record<string, unknown>> | undefined)?.[
+                    def.namespace
+                  ]?.[def.key]
+                }
                 onEditDefinition={() => setEditDef(def)}
               />
             ))}

--- a/packages/evershop/src/components/admin/metafield/MetafieldValueInput.tsx
+++ b/packages/evershop/src/components/admin/metafield/MetafieldValueInput.tsx
@@ -1,3 +1,4 @@
+import { Editor, type Row } from '@components/common/form/Editor.js';
 import { InputField } from '@components/common/form/InputField.js';
 import { NumberField } from '@components/common/form/NumberField.js';
 import { ReactSelectField } from '@components/common/form/ReactSelectField.js';
@@ -32,7 +33,6 @@ export interface FieldDescriptor {
   type: string;
   isList?: boolean;
   required?: boolean;
-  referenceType?: string;
   validations?: Validation[];
   subFields?: FieldDescriptor[];
 }
@@ -117,41 +117,6 @@ function toValidationRules(
   return Object.keys(rules).length ? rules : undefined;
 }
 
-/** Money: amount only — currency is fixed to the store currency (shop.currency). */
-function MoneyInput({ name, currency }: { name: string; currency: string }) {
-  const { control } = useFormContext();
-  return (
-    <Controller
-      control={control}
-      name={name as never}
-      render={({ field }) => {
-        const v =
-          field.value && typeof field.value === 'object'
-            ? (field.value as { amount?: number })
-            : {};
-        return (
-          <div className="flex items-center gap-2">
-            <Input
-              type="number"
-              step="any"
-              placeholder="0.00"
-              value={v.amount ?? ''}
-              onChange={(e) => {
-                const raw = e.target.value;
-                field.onChange(
-                  raw === '' ? undefined : { amount: Number(raw), currency }
-                );
-              }}
-              className="flex-1"
-            />
-            <span className="text-sm text-muted-foreground">{currency}</span>
-          </div>
-        );
-      }}
-    />
-  );
-}
-
 /** URL: uses the LinkPicker (page / category / product / custom URL). */
 function UrlInput({ name }: { name: string }) {
   const { control } = useFormContext();
@@ -173,12 +138,10 @@ function UrlInput({ name }: { name: string }) {
 function ScalarInput({
   field,
   name,
-  currency,
   isSubField
 }: {
   field: FieldDescriptor;
   name: string;
-  currency: string;
   isSubField?: boolean;
 }) {
   const validation = toValidationRules(field, !isSubField);
@@ -188,16 +151,6 @@ function ScalarInput({
         <TextareaField
           name={name}
           rows={3}
-          placeholder={_('Enter text')}
-          validation={validation}
-        />
-      );
-    case 'rich_text':
-      // A full WYSIWYG can be swapped in later; a textarea is a safe default.
-      return (
-        <TextareaField
-          name={name}
-          rows={6}
           placeholder={_('Enter text')}
           validation={validation}
         />
@@ -228,27 +181,6 @@ function ScalarInput({
       return <InputField name={name} type="color" validation={validation} />;
     case 'url':
       return <UrlInput name={name} />;
-    case 'money':
-      return <MoneyInput name={name} currency={currency} />;
-    case 'reference':
-      return (
-        <div className="flex gap-2">
-          <InputField
-            name={`${name}.referenceType`}
-            defaultValue={field.referenceType}
-            placeholder={_('Reference type')}
-            wrapperClassName="w-44"
-          />
-          <InputField
-            name={`${name}.id`}
-            type="number"
-            placeholder={_('ID')}
-            wrapperClassName="flex-1"
-          />
-        </div>
-      );
-    case 'json':
-      return <TextareaField name={name} rows={4} placeholder="{ }" />;
     case 'short_text':
     default:
       return (
@@ -273,7 +205,7 @@ function ListItemInput({
   onChange: (value: unknown) => void;
 }) {
   const str = value === undefined || value === null ? '' : String(value);
-  if (type === 'long_text' || type === 'rich_text') {
+  if (type === 'long_text') {
     return (
       <Textarea
         rows={2}
@@ -416,12 +348,10 @@ function ListValueEditor({
 /** Labelled sub-field inputs for a group (one object's worth). */
 function GroupFields({
   subFields,
-  name,
-  currency
+  name
 }: {
   subFields: FieldDescriptor[];
   name: string;
-  currency: string;
 }) {
   return (
     <div className="space-y-3">
@@ -434,7 +364,6 @@ function GroupFields({
           <MetafieldValueInput
             field={sub}
             name={`${name}.${sub.key}`}
-            currency={currency}
             isSubField
           />
         </div>
@@ -446,12 +375,10 @@ function GroupFields({
 /** Repeater of group cards (the `group` + isList case), one card per object. */
 function GroupListRepeater({
   field,
-  name,
-  currency
+  name
 }: {
   field: FieldDescriptor;
   name: string;
-  currency: string;
 }) {
   const { control } = useFormContext();
   const { fields, append, remove, move } = useFieldArray({
@@ -469,7 +396,6 @@ function GroupListRepeater({
             <GroupFields
               subFields={field.subFields || []}
               name={`${name}.${index}`}
-              currency={currency}
             />
           </div>
           <div className="flex flex-col gap-1 pt-1">
@@ -516,6 +442,86 @@ function GroupListRepeater({
 }
 
 /**
+ * Repeater of block Editors — the `rich_text` + isList case. Each item is one
+ * block document stored as `{ content: Row[] }` (an object so useFieldArray's
+ * add/remove/reorder reshuffle cleanly). Each Editor is keyed by the field-array
+ * id and seeded once from the stored value at its index.
+ */
+function RichTextListEditor({
+  name,
+  initialValue
+}: {
+  name: string;
+  initialValue?: unknown;
+}) {
+  const { control } = useFormContext();
+  const { fields, append, remove, move } = useFieldArray({
+    control,
+    name: name as never
+  });
+  const initials = Array.isArray(initialValue) ? (initialValue as any[]) : [];
+  return (
+    <div className="space-y-2">
+      {fields.map((item, index) => (
+        <div
+          key={item.id}
+          className="flex items-start gap-2 rounded-md border border-divider bg-card p-2"
+        >
+          <div className="flex-1">
+            <Editor
+              name={`${name}.${index}.content`}
+              value={
+                Array.isArray(initials[index]?.content)
+                  ? (initials[index].content as Row[])
+                  : []
+              }
+              columnToolbar={false}
+            />
+          </div>
+          <div className="flex flex-col gap-1 pt-1">
+            <button
+              type="button"
+              aria-label={_('Move up')}
+              onClick={() => move(index, index - 1)}
+              disabled={index === 0}
+              className="rounded p-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              <ChevronUp className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label={_('Move down')}
+              onClick={() => move(index, index + 1)}
+              disabled={index === fields.length - 1}
+              className="rounded p-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label={_('Remove item')}
+              onClick={() => remove(index)}
+              className="rounded p-1 text-muted-foreground hover:bg-muted/60 hover:text-destructive"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => append({ content: [] } as never)}
+      >
+        <Plus className="mr-1 h-3.5 w-3.5" />
+        {_('Add item')}
+      </Button>
+    </div>
+  );
+}
+
+/**
  * Renders the value input for one field descriptor, bound to `name` in the
  * surrounding form. `choices` → React-Select; `group` → sub-fields (or a card
  * repeater when a list); other lists → the controlled list editor; otherwise a
@@ -524,15 +530,32 @@ function GroupListRepeater({
 export function MetafieldValueInput({
   field,
   name,
-  currency = 'USD',
+  initialValue,
   isSubField = false
 }: {
   field: FieldDescriptor;
   name: string;
-  currency?: string;
+  /** Stored value used to seed the block Editor for `rich_text` (see below). */
+  initialValue?: unknown;
   /** True when rendered as a group sub-field — suppresses client `required`. */
   isSubField?: boolean;
 }) {
+  // rich_text uses the EverShop block Editor, which snapshots its value once on
+  // mount. Seed it straight from the stored value (not the form state, which is
+  // populated by a later effect) so an existing entity prefills correctly.
+  if (field.type === 'rich_text') {
+    if (field.isList) {
+      return <RichTextListEditor name={name} initialValue={initialValue} />;
+    }
+    return (
+      <Editor
+        name={name}
+        value={Array.isArray(initialValue) ? (initialValue as Row[]) : []}
+        columnToolbar={false}
+      />
+    );
+  }
+
   const choices = choicesOf(field);
 
   if (
@@ -553,29 +576,13 @@ export function MetafieldValueInput({
   }
 
   if (field.type === 'group') {
-    if (field.isList)
-      return (
-        <GroupListRepeater field={field} name={name} currency={currency} />
-      );
-    return (
-      <GroupFields
-        subFields={field.subFields || []}
-        name={name}
-        currency={currency}
-      />
-    );
+    if (field.isList) return <GroupListRepeater field={field} name={name} />;
+    return <GroupFields subFields={field.subFields || []} name={name} />;
   }
 
   if (field.isList) {
     return <ListValueEditor field={field} name={name} />;
   }
 
-  return (
-    <ScalarInput
-      field={field}
-      name={name}
-      currency={currency}
-      isSubField={isSubField}
-    />
-  );
+  return <ScalarInput field={field} name={name} isSubField={isSubField} />;
 }

--- a/packages/evershop/src/components/admin/metafield/StandaloneMetafieldCard.tsx
+++ b/packages/evershop/src/components/admin/metafield/StandaloneMetafieldCard.tsx
@@ -18,12 +18,10 @@ import { MetafieldSection } from './MetafieldSection.js';
 export function StandaloneMetafieldCard({
   ownerType,
   values,
-  currency = 'USD',
   saveUrl
 }: {
   ownerType: string;
   values?: Record<string, unknown>;
-  currency?: string;
   saveUrl: string;
 }): React.ReactElement {
   const [submitting, setSubmitting] = useState(false);
@@ -48,11 +46,7 @@ export function StandaloneMetafieldCard({
 
   return (
     <Form id={formId} submitBtn={false} onSubmit={handleSubmit}>
-      <MetafieldSection
-        ownerType={ownerType}
-        values={values}
-        currency={currency}
-      />
+      <MetafieldSection ownerType={ownerType} values={values} />
       <div className="mt-3 flex justify-end">
         <Button
           type="button"

--- a/packages/evershop/src/components/common/form/Editor.tsx
+++ b/packages/evershop/src/components/common/form/Editor.tsx
@@ -70,8 +70,9 @@ const SortableRow: React.FC<{
   removeRow: (rowId: string) => void;
   moveRowUp: (rowId: string) => void;
   moveRowDown: (rowId: string) => void;
+  showActions: boolean;
   children: React.ReactNode;
-}> = ({ row, removeRow, moveRowUp, moveRowDown, children }) => {
+}> = ({ row, removeRow, moveRowUp, moveRowDown, showActions, children }) => {
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
   const actionsRef = React.useRef<HTMLDivElement>(null);
 
@@ -114,6 +115,7 @@ const SortableRow: React.FC<{
       ref={setNodeRef}
       style={style}
     >
+      {showActions && (
       <div
         className="row__actions"
         ref={actionsRef}
@@ -209,6 +211,7 @@ const SortableRow: React.FC<{
           </div>
         )}
       </div>
+      )}
       {children}
     </div>
   );
@@ -232,13 +235,21 @@ export interface EditorProps {
    * Opt-in: enable the Product List block for this editor. Default OFF.
    */
   enableProductList?: boolean;
+  /**
+   * Show the row/column layout toolbar (RowTemplates) below the editor and the
+   * per-row actions (drag / move / delete). Default ON. Turn OFF for a simple
+   * single-column editor (e.g. metafields): the layout chrome is hidden and one
+   * column is seeded so there is always an area to type in.
+   */
+  columnToolbar?: boolean;
 }
 
 export const Editor: React.FC<EditorProps> = ({
   name,
   value = [],
   label,
-  enableProductList = false
+  enableProductList = false,
+  columnToolbar = true
 }) => {
   const client = useClient();
   // Data source for the Product List tool's built-in search modal.
@@ -362,8 +373,8 @@ export const Editor: React.FC<EditorProps> = ({
     onError: (error: string) => void;
   } | null>(null);
   const { register, setValue } = useScopedFormContext();
-  const [rows, setRows] = React.useState(
-    value
+  const [rows, setRows] = React.useState(() => {
+    const initial = value
       ? value.map((row) => {
           const rowId = `r__${uuidv4()}`;
           return {
@@ -380,8 +391,31 @@ export const Editor: React.FC<EditorProps> = ({
             })
           };
         })
-      : []
-  );
+      : [];
+    // Seed a single-column row when starting empty so the editor always has a
+    // visible, editable area instead of only the (optional) layout toolbar. With
+    // the toolbar off this is also the only way to get an initial row. An empty
+    // row is already a reachable state (add a row, type nothing), so this adds no
+    // new shape for consumers.
+    if (initial.length === 0) {
+      return [
+        {
+          id: `r__${uuidv4()}`,
+          size: 1,
+          className: getRowClasses(1),
+          columns: [
+            {
+              id: `c__${uuidv4()}`,
+              size: 1,
+              className: getColumnClasses(1),
+              data: {}
+            }
+          ]
+        }
+      ];
+    }
+    return initial;
+  });
   const editors = React.useRef({});
 
   const sensors = useSensors(
@@ -543,6 +577,7 @@ export const Editor: React.FC<EditorProps> = ({
                     removeRow={removeRow}
                     moveRowUp={moveRowUp}
                     moveRowDown={moveRowDown}
+                    showActions={columnToolbar}
                   >
                     <div
                       className={`row grid divide-x gap-x-3 divide-dashed ${row.className}`}
@@ -565,11 +600,13 @@ export const Editor: React.FC<EditorProps> = ({
             </SortableContext>
           </DndContext>
         </div>
-        <div className="flex justify-center">
-          <div className="flex justify-center flex-col mt-5">
-            <RowTemplates addRow={addRow} />
+        {columnToolbar && (
+          <div className="flex justify-center">
+            <div className="flex justify-center flex-col mt-5">
+              <RowTemplates addRow={addRow} />
+            </div>
           </div>
-        </div>
+        )}
       </div>
       <input type="hidden" {...register(name)} />
       {openFileBrowser && (

--- a/packages/evershop/src/lib/metafield/compileField.ts
+++ b/packages/evershop/src/lib/metafield/compileField.ts
@@ -1,4 +1,3 @@
-import { getStoreCurrency } from '../../modules/setting/services/setting.js';
 import { MAX_DEPTH } from './types.js';
 import type { FieldDescriptor, Validation } from './types.js';
 
@@ -36,7 +35,6 @@ function compileScalar(field: FieldDescriptor): JSONSchema {
   switch (field.type) {
     case 'short_text':
     case 'long_text':
-    case 'rich_text':
     case 'url':
       return { type: 'string' };
     case 'color':
@@ -49,33 +47,6 @@ function compileScalar(field: FieldDescriptor): JSONSchema {
       return { type: 'number' };
     case 'boolean':
       return { type: 'boolean' };
-    case 'money': {
-      // currency must match the store currency (spec §3.6) — admin setting, legacy config fallback
-      const currency = getStoreCurrency();
-      return {
-        type: 'object',
-        properties: {
-          amount: { type: 'number' },
-          currency: currency
-            ? { type: 'string', const: currency }
-            : { type: 'string' }
-        },
-        required: ['amount', 'currency'],
-        additionalProperties: false
-      };
-    }
-    case 'reference':
-      return {
-        type: 'object',
-        properties: {
-          referenceType: { type: 'string' },
-          id: { type: ['integer', 'string'] }
-        },
-        required: ['referenceType', 'id'],
-        additionalProperties: false
-      };
-    case 'json':
-      return {}; // arbitrary JSON — opaque, bypasses the depth guard
     default:
       return {};
   }
@@ -91,6 +62,12 @@ export function compileField(
   depth = 1,
   max = MAX_DEPTH
 ): JSONSchema {
+  // rich_text holds EverShop block-editor content, validated opaquely. A single
+  // value is a Row[]; a list is an array of `{ content: Row[] }` items. Either
+  // way the top level is an array.
+  if (field.type === 'rich_text') {
+    return { type: 'array' };
+  }
   let schema: JSONSchema;
   if (field.type === 'group') {
     if (depth >= max) {

--- a/packages/evershop/src/lib/metafield/definition.ts
+++ b/packages/evershop/src/lib/metafield/definition.ts
@@ -29,7 +29,6 @@ export interface CreateDefinitionInput {
   required?: boolean;
   translatable?: boolean;
   visibleToCustomer?: boolean;
-  referenceType?: string;
   validations?: Validation[];
   appearance?: Record<string, unknown>;
   subFields?: FieldDescriptor[];
@@ -56,7 +55,6 @@ function rowToDefinition(row: Record<string, any>): MetafieldDefinition {
     required: row.required,
     translatable: row.translatable,
     visibleToCustomer: row.visible_to_customer,
-    referenceType: row.reference_type ?? undefined,
     validations: row.validations ?? [],
     appearance: row.appearance ?? {},
     subFields: row.sub_fields ?? [],
@@ -124,9 +122,6 @@ export async function createMetafieldDefinition(
   if (!input.ownerType || !input.key || !input.name || !input.type) {
     throw httpError('ownerType, key, name and type are required', 400);
   }
-  if (input.type === 'reference' && !input.referenceType) {
-    throw httpError('referenceType is required when type is "reference"', 400);
-  }
   assertCompilable(input);
 
   // Existence check — a definition with the same key may not already exist.
@@ -151,7 +146,6 @@ export async function createMetafieldDefinition(
       name: input.name,
       description: input.description ?? null,
       field_type: input.type,
-      reference_type: input.referenceType ?? null,
       is_list: input.isList ?? false,
       required: input.required ?? false,
       translatable: input.translatable ?? false,
@@ -201,8 +195,6 @@ export async function updateMetafieldDefinition(
   if (patch.translatable !== undefined) data.translatable = patch.translatable;
   if (patch.visibleToCustomer !== undefined)
     data.visible_to_customer = patch.visibleToCustomer;
-  if (patch.referenceType !== undefined)
-    data.reference_type = patch.referenceType;
   if (patch.validations !== undefined) data.validations = patch.validations;
   if (patch.appearance !== undefined) data.appearance = patch.appearance;
   if (patch.subFields !== undefined) data.sub_fields = patch.subFields;

--- a/packages/evershop/src/lib/metafield/tests/unit/compileField.test.ts
+++ b/packages/evershop/src/lib/metafield/tests/unit/compileField.test.ts
@@ -14,9 +14,17 @@ function field(
 
 describe('compileField — scalars', () => {
   test('text-like types compile to a plain string schema', () => {
-    for (const type of ['short_text', 'long_text', 'rich_text', 'url'] as const) {
+    for (const type of ['short_text', 'long_text', 'url'] as const) {
       expect(compileField(field({ type }))).toEqual({ type: 'string' });
     }
+  });
+
+  test('rich_text compiles to an opaque array (block-editor content)', () => {
+    expect(compileField(field({ type: 'rich_text' }))).toEqual({ type: 'array' });
+    // Both single and list compile to an opaque top-level array.
+    expect(compileField(field({ type: 'rich_text', isList: true }))).toEqual({
+      type: 'array'
+    });
   });
 
   test('integer / number / boolean', () => {
@@ -34,18 +42,6 @@ describe('compileField — scalars', () => {
     expect(validate('#fff')).toBe(false);
   });
 
-  test('reference is a closed {referenceType, id} object', () => {
-    const schema = compileField(field({ type: 'reference', referenceType: 'product' }));
-    const validate = ajv().compile(schema);
-    expect(validate({ referenceType: 'product', id: 7 })).toBe(true);
-    expect(validate({ referenceType: 'product', id: 'uuid-str' })).toBe(true);
-    expect(validate({ referenceType: 'product' })).toBe(false); // missing id
-    expect(validate({ referenceType: 'product', id: 7, extra: 1 })).toBe(false);
-  });
-
-  test('json is unconstrained', () => {
-    expect(compileField(field({ type: 'json' }))).toEqual({});
-  });
 });
 
 describe('compileField — validations', () => {

--- a/packages/evershop/src/lib/metafield/types.ts
+++ b/packages/evershop/src/lib/metafield/types.ts
@@ -8,9 +8,6 @@ export type MetafieldType =
   | 'date'
   | 'color'
   | 'url'
-  | 'money'
-  | 'json'
-  | 'reference'
   | 'group';
 
 export const METAFIELD_TYPES: MetafieldType[] = [
@@ -23,9 +20,6 @@ export const METAFIELD_TYPES: MetafieldType[] = [
   'date',
   'color',
   'url',
-  'money',
-  'json',
-  'reference',
   'group'
 ];
 
@@ -57,8 +51,6 @@ export interface FieldDescriptor {
   translatable?: boolean;
   validations?: Validation[];
   appearance?: Record<string, unknown>;
-  /** Opaque label for `reference` targets; the consumer dereferences it. */
-  referenceType?: string;
   subFields?: FieldDescriptor[];
 }
 

--- a/packages/evershop/src/lib/metafield/validate.ts
+++ b/packages/evershop/src/lib/metafield/validate.ts
@@ -12,7 +12,6 @@ function descriptorOf(def: MetafieldDefinition): FieldDescriptor {
     required: def.required,
     validations: def.validations,
     appearance: def.appearance,
-    referenceType: def.referenceType,
     subFields: def.subFields
   };
 }
@@ -35,6 +34,35 @@ function isBlank(value: unknown): boolean {
   return value === undefined || value === null || value === '';
 }
 
+/** A single editor block carries real content (non-empty text / items / media). */
+function blockHasContent(block: any): boolean {
+  const data = block?.data;
+  if (!data || typeof data !== 'object') return false;
+  if (typeof data.text === 'string') {
+    // Strip inline HTML/whitespace: an empty paragraph block is not content.
+    return data.text.replace(/<[^>]*>/g, '').trim().length > 0;
+  }
+  if (Array.isArray(data.items)) return data.items.length > 0;
+  // image / raw / productList / etc. — any populated block counts as content.
+  return Object.keys(data).length > 0;
+}
+
+/** True when block-editor content (Row[]) has at least one non-empty block. */
+function richTextHasBlocks(rows: unknown): boolean {
+  return (
+    Array.isArray(rows) &&
+    rows.some(
+      (row: any) =>
+        Array.isArray(row?.columns) &&
+        row.columns.some(
+          (col: any) =>
+            Array.isArray(col?.data?.blocks) &&
+            col.data.blocks.some(blockHasContent)
+        )
+    )
+  );
+}
+
 /**
  * Coerce an "empty" value to `undefined` so untouched optional fields are treated
  * as not-provided rather than validated. The form serializes every field on
@@ -44,6 +72,24 @@ function isBlank(value: unknown): boolean {
  */
 function normalize(field: FieldDescriptor, value: unknown): unknown {
   if (isBlank(value)) return undefined;
+
+  // rich_text is EverShop block-editor content (Row[]). A list holds one document
+  // per item as `{ content: Row[] }`. Structurally-empty content (no blocks in any
+  // column) counts as unset — `required` is enforced and empty editor shells /
+  // empty items are dropped rather than persisted.
+  if (field.type === 'rich_text') {
+    if (field.isList) {
+      if (!Array.isArray(value)) return undefined;
+      const items = (value as any[])
+        .map((item) =>
+          item && typeof item === 'object' ? (item as any).content : undefined
+        )
+        .filter((rows) => richTextHasBlocks(rows))
+        .map((rows) => ({ content: rows }));
+      return items.length ? items : undefined;
+    }
+    return richTextHasBlocks(value) ? value : undefined;
+  }
 
   if (field.isList) {
     if (!Array.isArray(value)) return undefined;
@@ -62,19 +108,6 @@ function normalize(field: FieldDescriptor, value: unknown): unknown {
       if (nv !== undefined) out[sub.key] = nv;
     }
     return Object.keys(out).length ? out : undefined;
-  }
-
-  if (field.type === 'reference') {
-    const v = value as { referenceType?: unknown; id?: unknown };
-    // The default `referenceType` alone is not a value — an empty `id` means unset.
-    if (isBlank(v.id)) return undefined;
-    return { referenceType: v.referenceType, id: v.id };
-  }
-
-  if (field.type === 'money') {
-    const v = value as { amount?: unknown };
-    if (isBlank(v.amount)) return undefined;
-    return value;
   }
 
   return value;

--- a/packages/evershop/src/modules/base/api/createMetafieldDefinition/createMetafieldDefinition.ts
+++ b/packages/evershop/src/modules/base/api/createMetafieldDefinition/createMetafieldDefinition.ts
@@ -20,7 +20,6 @@ export default async (
       name: b.name,
       description: b.description,
       type: b.fieldType,
-      referenceType: b.referenceType,
       isList: b.isList,
       required: b.required,
       translatable: b.translatable,

--- a/packages/evershop/src/modules/base/api/createMetafieldDefinition/payloadSchema.json
+++ b/packages/evershop/src/modules/base/api/createMetafieldDefinition/payloadSchema.json
@@ -48,9 +48,6 @@
         "date",
         "color",
         "url",
-        "money",
-        "json",
-        "reference",
         "group"
       ],
       "errorMessage": {
@@ -58,7 +55,6 @@
         "enum": "fieldType must be one of the supported metafield types"
       }
     },
-    "referenceType": { "type": "string" },
     "isList": { "type": "boolean" },
     "required": { "type": "boolean" },
     "translatable": { "type": "boolean" },

--- a/packages/evershop/src/modules/base/api/updateMetafieldDefinition/payloadSchema.json
+++ b/packages/evershop/src/modules/base/api/updateMetafieldDefinition/payloadSchema.json
@@ -16,7 +16,6 @@
     "required": { "type": "boolean" },
     "translatable": { "type": "boolean" },
     "visibleToCustomer": { "type": "boolean" },
-    "referenceType": { "type": "string" },
     "validations": { "type": "array" },
     "appearance": { "type": "object" },
     "subFields": { "type": "array" },

--- a/packages/evershop/src/modules/base/api/updateMetafieldDefinition/updateMetafieldDefinition.ts
+++ b/packages/evershop/src/modules/base/api/updateMetafieldDefinition/updateMetafieldDefinition.ts
@@ -26,7 +26,6 @@ export default async (
       required: b.required,
       translatable: b.translatable,
       visibleToCustomer: b.visibleToCustomer,
-      referenceType: b.referenceType,
       validations: b.validations,
       appearance: b.appearance,
       subFields: b.subFields,

--- a/packages/evershop/src/modules/base/graphql/types/Metafield/Metafield.graphql
+++ b/packages/evershop/src/modules/base/graphql/types/Metafield/Metafield.graphql
@@ -10,9 +10,6 @@ enum MetafieldType {
   DATE
   COLOR
   URL
-  MONEY
-  JSON
-  REFERENCE
   GROUP
 }
 

--- a/packages/evershop/src/modules/base/graphql/types/Metafield/Metafield.resolvers.ts
+++ b/packages/evershop/src/modules/base/graphql/types/Metafield/Metafield.resolvers.ts
@@ -14,9 +14,6 @@ export default {
     DATE: 'date',
     COLOR: 'color',
     URL: 'url',
-    MONEY: 'money',
-    JSON: 'json',
-    REFERENCE: 'reference',
     GROUP: 'group'
   }
 };

--- a/packages/evershop/src/modules/base/graphql/types/Metafield/MetafieldDefinition.admin.graphql
+++ b/packages/evershop/src/modules/base/graphql/types/Metafield/MetafieldDefinition.admin.graphql
@@ -14,7 +14,6 @@ type MetafieldDefinition {
   isList: Boolean!
   required: Boolean!
   visibleToCustomer: Boolean!
-  referenceType: String
   validations: JSON
   subFields: JSON
   appearance: JSON

--- a/packages/evershop/src/modules/base/migration/Version-1.0.3.ts
+++ b/packages/evershop/src/modules/base/migration/Version-1.0.3.ts
@@ -6,13 +6,12 @@ export default async (connection: PoolClient) => {
     connection,
     `CREATE TYPE metafield_type AS ENUM (
       'short_text', 'long_text', 'rich_text', 'integer', 'number', 'boolean',
-      'date', 'color', 'url', 'money', 'json', 'reference', 'group'
+      'date', 'color', 'url', 'group'
     )`
   );
 
-  // The typed, reusable field declaration. owner_type / reference_type are open
-  // (plain varchar) so any entity — core or third-party — can opt in without the
-  // core enumerating it.
+  // The typed, reusable field declaration. owner_type is open (plain varchar) so
+  // any entity — core or third-party — can opt in without the core enumerating it.
   await execute(
     connection,
     `CREATE TABLE "metafield_definition" (
@@ -24,7 +23,6 @@ export default async (connection: PoolClient) => {
       "name" varchar(255) NOT NULL,
       "description" text,
       "field_type" metafield_type NOT NULL,
-      "reference_type" varchar(64),
       "is_list" boolean NOT NULL DEFAULT false,
       "required" boolean NOT NULL DEFAULT false,
       "translatable" boolean NOT NULL DEFAULT false,
@@ -37,7 +35,6 @@ export default async (connection: PoolClient) => {
       "updated_at" timestamptz NOT NULL DEFAULT now(),
       CONSTRAINT "METAFIELD_DEFINITION_UUID_UNIQUE" UNIQUE ("uuid"),
       CONSTRAINT "METAFIELD_DEFINITION_KEY_UNIQUE" UNIQUE ("owner_type", "namespace", "field_key"),
-      CONSTRAINT "METAFIELD_REFERENCE_TYPE_IFF_REFERENCE" CHECK (("field_type" = 'reference') = ("reference_type" IS NOT NULL)),
       CONSTRAINT "METAFIELD_SUB_FIELDS_IFF_GROUP" CHECK (("field_type" = 'group') = (jsonb_array_length("sub_fields") > 0))
     )`
   );

--- a/packages/evershop/src/modules/catalog/graphql/types/Category/Category.admin.resolvers.js
+++ b/packages/evershop/src/modules/catalog/graphql/types/Category/Category.admin.resolvers.js
@@ -8,7 +8,7 @@ export default {
     deleteApi: (category) => buildUrl('deleteCategory', { id: category.uuid }),
     addProductUrl: (category) =>
       buildUrl('addProductToCategory', { category_id: category.uuid }),
-    metaData: (category) => category.metaData ?? category.meta_data ?? {}
+    metaData: (category) => category.metaData ?? {}
   },
   Product: {
     removeFromCategoryUrl: async (product, _, { pool }) => {

--- a/packages/evershop/src/modules/catalog/graphql/types/Category/CategoryMetafields.resolvers.ts
+++ b/packages/evershop/src/modules/catalog/graphql/types/Category/CategoryMetafields.resolvers.ts
@@ -3,10 +3,7 @@ import {
   type MetaData
 } from '../../../../../lib/metafield/index.js';
 
-type CategoryParent = { metaData?: MetaData; meta_data?: MetaData };
-
-const metaOf = (category: CategoryParent): MetaData =>
-  category.metaData ?? category.meta_data ?? {};
+type CategoryParent = { metaData?: MetaData };
 
 export default {
   Category: {
@@ -15,7 +12,7 @@ export default {
       { namespace }: { namespace?: string },
       { user }: { user?: unknown }
     ) =>
-      shapeMetafields(metaOf(category), 'category', {
+      shapeMetafields(category.metaData ?? {}, 'category', {
         audience: user ? 'admin' : 'customer',
         namespace
       }),
@@ -24,7 +21,7 @@ export default {
       { namespace, key }: { namespace: string; key: string },
       { user }: { user?: unknown }
     ) => {
-      const all = await shapeMetafields(metaOf(category), 'category', {
+      const all = await shapeMetafields(category.metaData ?? {}, 'category', {
         audience: user ? 'admin' : 'customer',
         namespace
       });

--- a/packages/evershop/src/modules/catalog/graphql/types/Collection/Collection.admin.resolvers.js
+++ b/packages/evershop/src/modules/catalog/graphql/types/Collection/Collection.admin.resolvers.js
@@ -11,8 +11,7 @@ export default {
       buildUrl('updateCollection', { id: collection.uuid }),
     deleteApi: (collection) =>
       buildUrl('deleteCollection', { id: collection.uuid }),
-    metaData: (collection) =>
-      collection.metaData ?? collection.meta_data ?? {}
+    metaData: (collection) => collection.metaData ?? {}
   },
   Product: {
     removeFromCollectionUrl: async (product, _, { pool }) => {

--- a/packages/evershop/src/modules/catalog/graphql/types/Collection/CollectionMetafields.resolvers.ts
+++ b/packages/evershop/src/modules/catalog/graphql/types/Collection/CollectionMetafields.resolvers.ts
@@ -3,10 +3,7 @@ import {
   type MetaData
 } from '../../../../../lib/metafield/index.js';
 
-type CollectionParent = { metaData?: MetaData; meta_data?: MetaData };
-
-const metaOf = (collection: CollectionParent): MetaData =>
-  collection.metaData ?? collection.meta_data ?? {};
+type CollectionParent = { metaData?: MetaData };
 
 export default {
   Collection: {
@@ -15,7 +12,7 @@ export default {
       { namespace }: { namespace?: string },
       { user }: { user?: unknown }
     ) =>
-      shapeMetafields(metaOf(collection), 'collection', {
+      shapeMetafields(collection.metaData ?? {}, 'collection', {
         audience: user ? 'admin' : 'customer',
         namespace
       }),
@@ -24,7 +21,7 @@ export default {
       { namespace, key }: { namespace: string; key: string },
       { user }: { user?: unknown }
     ) => {
-      const all = await shapeMetafields(metaOf(collection), 'collection', {
+      const all = await shapeMetafields(collection.metaData ?? {}, 'collection', {
         audience: user ? 'admin' : 'customer',
         namespace
       });

--- a/packages/evershop/src/modules/catalog/pages/admin/categoryEdit+categoryNew/CategoryCustomFields.tsx
+++ b/packages/evershop/src/modules/catalog/pages/admin/categoryEdit+categoryNew/CategoryCustomFields.tsx
@@ -2,19 +2,11 @@ import { MetafieldSection } from '@components/admin/metafield/MetafieldSection.j
 import React from 'react';
 
 export default function CategoryCustomFields({
-  category,
-  setting
+  category
 }: {
   category?: { metaData?: Record<string, unknown> } | null;
-  setting?: { storeCurrency?: string } | null;
 }): React.ReactElement {
-  return (
-    <MetafieldSection
-      ownerType="category"
-      values={category?.metaData}
-      currency={setting?.storeCurrency ?? 'USD'}
-    />
-  );
+  return <MetafieldSection ownerType="category" values={category?.metaData} />;
 }
 
 export const layout = {
@@ -23,15 +15,11 @@ export const layout = {
 };
 
 // `metaData` is exposed admin-only (Category.admin.graphql) so the editor can
-// prefill current values. `storeCurrency` (= shop.currency) drives `money` fields.
-// On categoryNew the category is null and values are empty.
+// prefill current values. On categoryNew the category is null and values are empty.
 export const query = `
   query Query {
     category(id: getContextValue("categoryId", null)) {
       metaData
-    }
-    setting {
-      storeCurrency
     }
   }
 `;

--- a/packages/evershop/src/modules/catalog/pages/admin/collectionEdit+collectionNew/CollectionCustomFields.tsx
+++ b/packages/evershop/src/modules/catalog/pages/admin/collectionEdit+collectionNew/CollectionCustomFields.tsx
@@ -2,18 +2,12 @@ import { MetafieldSection } from '@components/admin/metafield/MetafieldSection.j
 import React from 'react';
 
 export default function CollectionCustomFields({
-  collection,
-  setting
+  collection
 }: {
   collection?: { metaData?: Record<string, unknown> } | null;
-  setting?: { storeCurrency?: string } | null;
 }): React.ReactElement {
   return (
-    <MetafieldSection
-      ownerType="collection"
-      values={collection?.metaData}
-      currency={setting?.storeCurrency ?? 'USD'}
-    />
+    <MetafieldSection ownerType="collection" values={collection?.metaData} />
   );
 }
 
@@ -22,16 +16,12 @@ export const layout = {
   sortOrder: 50
 };
 
-// `metaData` is exposed admin-only (Collection.admin.graphql) for prefill;
-// `storeCurrency` (= shop.currency) drives `money` fields. The collection edit
-// screen loads by code (collectionNew has none → values empty).
+// `metaData` is exposed admin-only (Collection.admin.graphql) for prefill. The
+// collection edit screen loads by code (collectionNew has none → values empty).
 export const query = `
   query Query {
     collection(code: getContextValue("collectionCode", null)) {
       metaData
-    }
-    setting {
-      storeCurrency
     }
   }
 `;

--- a/packages/evershop/src/modules/catalog/pages/admin/productEdit+productNew/ProductCustomFields.tsx
+++ b/packages/evershop/src/modules/catalog/pages/admin/productEdit+productNew/ProductCustomFields.tsx
@@ -6,16 +6,9 @@ export default function ProductCustomFields({
 }: {
   product?: {
     metaData?: Record<string, unknown>;
-    price?: { regular?: { currency?: string } };
   } | null;
 }): React.ReactElement {
-  return (
-    <MetafieldSection
-      ownerType="product"
-      values={product?.metaData}
-      currency={product?.price?.regular?.currency ?? 'USD'}
-    />
-  );
+  return <MetafieldSection ownerType="product" values={product?.metaData} />;
 }
 
 export const layout = {
@@ -24,17 +17,11 @@ export const layout = {
 };
 
 // `metaData` is exposed admin-only (Product.admin.graphql) so the editor can
-// prefill current values. `currency` (= shop.currency) drives `money` fields.
-// On productNew the product is null and values are empty.
+// prefill current values. On productNew the product is null and values are empty.
 export const query = `
   query Query {
     product(id: getContextValue("productId", null)) {
       metaData
-      price {
-        regular {
-          currency
-        }
-      }
     }
   }
 `;

--- a/packages/evershop/src/modules/customer/graphql/types/Customer/Customer.admin.resolvers.js
+++ b/packages/evershop/src/modules/customer/graphql/types/Customer/Customer.admin.resolvers.js
@@ -22,7 +22,7 @@ export default {
     editUrl: ({ uuid }) => buildUrl('customerEdit', { id: uuid }),
     updateApi: (customer) => buildUrl('updateCustomer', { id: customer.uuid }),
     deleteApi: (customer) => buildUrl('deleteCustomer', { id: customer.uuid }),
-    metaData: (customer) => customer.metaData ?? customer.meta_data ?? {},
+    metaData: (customer) => customer.metaData ?? {},
     updateMetafieldsApi: (customer) =>
       buildUrl('updateCustomerMetafields', { id: customer.uuid })
   }

--- a/packages/evershop/src/modules/customer/graphql/types/Customer/CustomerMetafields.resolvers.ts
+++ b/packages/evershop/src/modules/customer/graphql/types/Customer/CustomerMetafields.resolvers.ts
@@ -3,10 +3,7 @@ import {
   type MetaData
 } from '../../../../../lib/metafield/index.js';
 
-type CustomerParent = { metaData?: MetaData; meta_data?: MetaData };
-
-const metaOf = (customer: CustomerParent): MetaData =>
-  customer.metaData ?? customer.meta_data ?? {};
+type CustomerParent = { metaData?: MetaData };
 
 export default {
   Customer: {
@@ -15,7 +12,7 @@ export default {
       { namespace }: { namespace?: string },
       { user }: { user?: unknown }
     ) =>
-      shapeMetafields(metaOf(customer), 'customer', {
+      shapeMetafields(customer.metaData ?? {}, 'customer', {
         audience: user ? 'admin' : 'customer',
         namespace
       }),
@@ -24,7 +21,7 @@ export default {
       { namespace, key }: { namespace: string; key: string },
       { user }: { user?: unknown }
     ) => {
-      const all = await shapeMetafields(metaOf(customer), 'customer', {
+      const all = await shapeMetafields(customer.metaData ?? {}, 'customer', {
         audience: user ? 'admin' : 'customer',
         namespace
       });

--- a/packages/evershop/src/modules/customer/pages/admin/customerEdit/CustomerCustomFields.tsx
+++ b/packages/evershop/src/modules/customer/pages/admin/customerEdit/CustomerCustomFields.tsx
@@ -2,14 +2,12 @@ import { StandaloneMetafieldCard } from '@components/admin/metafield/StandaloneM
 import React from 'react';
 
 export default function CustomerCustomFields({
-  customer,
-  setting
+  customer
 }: {
   customer?: {
     metaData?: Record<string, unknown>;
     updateMetafieldsApi?: string;
   } | null;
-  setting?: { storeCurrency?: string } | null;
 }): React.ReactElement | null {
   // The customer admin screen is a read-only view, so the metafield editor is a
   // self-contained card that PATCHes to `updateMetafieldsApi` on Save.
@@ -18,7 +16,6 @@ export default function CustomerCustomFields({
     <StandaloneMetafieldCard
       ownerType="customer"
       values={customer.metaData}
-      currency={setting?.storeCurrency ?? 'USD'}
       saveUrl={customer.updateMetafieldsApi}
     />
   );
@@ -29,16 +26,12 @@ export const layout = {
   sortOrder: 80
 };
 
-// Edit-only (customerEdit route); `metaData` is admin-only, `storeCurrency`
-// (= shop.currency) drives `money` fields.
+// Edit-only (customerEdit route); `metaData` is admin-only.
 export const query = `
   query Query {
     customer(id: getContextValue("customerUuid", null)) {
       metaData
       updateMetafieldsApi
-    }
-    setting {
-      storeCurrency
     }
   }
 `;

--- a/packages/evershop/src/modules/oms/graphql/types/Order/Order.admin.resolvers.js
+++ b/packages/evershop/src/modules/oms/graphql/types/Order/Order.admin.resolvers.js
@@ -16,7 +16,7 @@ export default {
     editUrl: ({ uuid }) => buildUrl('orderEdit', { id: uuid }),
     createShipmentApi: ({ uuid }) => buildUrl('createShipment', { id: uuid }),
     cancelApi: ({ uuid }) => buildUrl('cancelOrder', { id: uuid }),
-    metaData: (order) => order.metaData ?? order.meta_data ?? {},
+    metaData: (order) => order.metaData ?? {},
     updateMetafieldsApi: ({ uuid }) =>
       buildUrl('updateOrderMetafields', { id: uuid }),
     customerUrl: async ({ customerId }, _, { pool }) => {

--- a/packages/evershop/src/modules/oms/graphql/types/Order/OrderMetafields.resolvers.ts
+++ b/packages/evershop/src/modules/oms/graphql/types/Order/OrderMetafields.resolvers.ts
@@ -3,10 +3,7 @@ import {
   type MetaData
 } from '../../../../../lib/metafield/index.js';
 
-type OrderParent = { metaData?: MetaData; meta_data?: MetaData };
-
-const metaOf = (order: OrderParent): MetaData =>
-  order.metaData ?? order.meta_data ?? {};
+type OrderParent = { metaData?: MetaData };
 
 export default {
   Order: {
@@ -15,7 +12,7 @@ export default {
       { namespace }: { namespace?: string },
       { user }: { user?: unknown }
     ) =>
-      shapeMetafields(metaOf(order), 'order', {
+      shapeMetafields(order.metaData ?? {}, 'order', {
         audience: user ? 'admin' : 'customer',
         namespace
       }),
@@ -24,7 +21,7 @@ export default {
       { namespace, key }: { namespace: string; key: string },
       { user }: { user?: unknown }
     ) => {
-      const all = await shapeMetafields(metaOf(order), 'order', {
+      const all = await shapeMetafields(order.metaData ?? {}, 'order', {
         audience: user ? 'admin' : 'customer',
         namespace
       });

--- a/packages/evershop/src/modules/oms/pages/admin/orderEdit/OrderCustomFields.tsx
+++ b/packages/evershop/src/modules/oms/pages/admin/orderEdit/OrderCustomFields.tsx
@@ -2,14 +2,12 @@ import { StandaloneMetafieldCard } from '@components/admin/metafield/StandaloneM
 import React from 'react';
 
 export default function OrderCustomFields({
-  order,
-  setting
+  order
 }: {
   order?: {
     metaData?: Record<string, unknown>;
     updateMetafieldsApi?: string;
   } | null;
-  setting?: { storeCurrency?: string } | null;
 }): React.ReactElement | null {
   // The order admin screen is a read-only view, so the metafield editor is a
   // self-contained card that PATCHes to `updateMetafieldsApi` on Save.
@@ -18,7 +16,6 @@ export default function OrderCustomFields({
     <StandaloneMetafieldCard
       ownerType="order"
       values={order.metaData}
-      currency={setting?.storeCurrency ?? 'USD'}
       saveUrl={order.updateMetafieldsApi}
     />
   );
@@ -29,16 +26,12 @@ export const layout = {
   sortOrder: 25
 };
 
-// `metaData` is admin-only; `storeCurrency` (= shop.currency) drives `money`
-// fields. The order is loaded by uuid (context key "orderId").
+// `metaData` is admin-only. The order is loaded by uuid (context key "orderId").
 export const query = `
   query Query {
     order(uuid: getContextValue("orderId")) {
       metaData
       updateMetafieldsApi
-    }
-    setting {
-      storeCurrency
     }
   }
 `;

--- a/packages/evershop/src/modules/setting/pages/admin/storeSetting/StoreSetting.tsx
+++ b/packages/evershop/src/modules/setting/pages/admin/storeSetting/StoreSetting.tsx
@@ -32,7 +32,6 @@ function ShopCustomFields({
 }: {
   setting?: {
     metaData?: Record<string, unknown>;
-    storeCurrency?: string;
     shopMetafieldsApi?: string;
   } | null;
 }): React.ReactElement | null {
@@ -44,7 +43,6 @@ function ShopCustomFields({
     <StandaloneMetafieldCard
       ownerType="shop"
       values={setting.metaData}
-      currency={setting.storeCurrency ?? 'USD'}
       saveUrl={setting.shopMetafieldsApi}
     />
   );
@@ -649,7 +647,6 @@ export default function StoreSetting({
             <ShopCustomFields
               setting={{
                 metaData,
-                storeCurrency,
                 shopMetafieldsApi
               }}
             />


### PR DESCRIPTION
…oggle

- Remove the `json`, `reference`, and `money` field types across the whole stack: the type union/enum, AJV compile, DB `metafield_type` enum, the `reference_type` column + its CHECK constraint, GraphQL enum, REST payload schemas, and the admin editor/value inputs. Also drop the now-dead `referenceType` and `currency` plumbing that existed only for those types.

- Remove the dead `?? meta_data` fallback from the category/collection/order/ customer resolvers. Every entity's row is camelCased before it reaches the resolvers, so the fallback never fired; all five entities now match the Product `metaData ?? {}` template.

- `rich_text` now uses the EverShop block Editor instead of a plain textarea. Its value is block content (`Row[]`); a list is a repeater of editors (`{ content: Row[] }` items) with add / remove / reorder. Schema is validated opaquely and structurally-empty content normalizes to unset so `required` still works.

- `Editor`: add a `columnToolbar` prop (default on). When off (metafields) the row/column layout toolbar and per-row actions are hidden. Always seed one single-column row when the editor starts empty, so new editors (CMS page, product/category/collection/blog descriptions, metafields) open with an editable area instead of a bare layout picker.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
