### PR TITLE
feat: sitemap.xml + robots.txt generation #506

### DIFF
--- a/packages/evershop/package.json
+++ b/packages/evershop/package.json
@@ -123,6 +123,10 @@
       "import": "./dist/modules/promotion/services/index.js",
       "types": "./dist/modules/promotion/services/index.d.ts"
     },
+    "./base/services/sitemap": {
+      "import": "./dist/modules/base/services/sitemap/index.js",
+      "types": "./dist/modules/base/services/sitemap/index.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/evershop/src/lib/util/getConfig.ts
+++ b/packages/evershop/src/lib/util/getConfig.ts
@@ -152,6 +152,32 @@ type ConfigStructure = {
       anonymousTokenTtlDays: number;
     };
   };
+  sitemap: {
+    enabled: boolean;
+    schedule: string;
+    maxUrlsPerFile: number;
+    maxAge: number;
+    hreflang: boolean;
+    staticPaths: string[];
+    changefreq: {
+      product: string;
+      category: string;
+      cmsPage: string;
+      landingPage: string;
+      static: string;
+    };
+    priority: {
+      product: number;
+      category: number;
+      cmsPage: number;
+      landingPage: number;
+      static: number;
+    };
+    robots: {
+      enabled: boolean;
+      disallow: string[];
+    };
+  };
 };
 
 type PathValue<T, P extends string> = P extends keyof T

--- a/packages/evershop/src/modules/base/bootstrap.js
+++ b/packages/evershop/src/modules/base/bootstrap.js
@@ -1,7 +1,13 @@
+import path from 'path';
+import config from 'config';
+import { registerJob } from '../../lib/cronjob/jobManager.js';
 import { loadAllLocales } from '../../lib/locale/dictionary.js';
 import { assertValidHomeUrlEnv } from '../../lib/util/getBaseUrl.js';
 import { merge } from '../../lib/util/merge.js';
 import { addProcessor } from '../../lib/util/registry.js';
+import { getBuiltinSitemapCollectors } from './services/sitemap/collectors/builtins.js';
+import { SITEMAP_CONFIG_DEFAULTS, getSitemapConfig } from './services/sitemap/config.js';
+import { registerSitemapCollector } from './services/sitemap/registry.js';
 
 export default async () => {
   // Fail fast if EVERSHOP_HOME_URL is set to something that isn't a valid
@@ -82,5 +88,51 @@ export default async () => {
       }
     });
     return schema;
+  });
+
+  // --- Sitemap (wiki/sitemap-design.md) ---
+  // Config defaults, a validation-schema slice, the built-in URL collectors, and the
+  // regeneration cron. Registered here (before the bootstrap lock) so the registry has the
+  // collectors and the cron child has the job.
+  config.util.setModuleDefaults('sitemap', SITEMAP_CONFIG_DEFAULTS);
+  addProcessor('configurationSchema', (schema) => {
+    merge(schema, {
+      properties: {
+        sitemap: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean' },
+            schedule: { type: 'string' },
+            maxUrlsPerFile: { type: 'number' },
+            maxAge: { type: 'number' },
+            hreflang: { type: 'boolean' },
+            staticPaths: { type: 'array', items: { type: 'string' } },
+            changefreq: { type: 'object' },
+            priority: { type: 'object' },
+            robots: {
+              type: 'object',
+              properties: {
+                enabled: { type: 'boolean' },
+                disallow: { type: 'array', items: { type: 'string' } }
+              }
+            }
+          }
+        }
+      }
+    });
+    return schema;
+  });
+  getBuiltinSitemapCollectors().forEach(registerSitemapCollector);
+  const sitemapConfig = getSitemapConfig();
+  registerJob({
+    name: 'generateSitemap',
+    schedule: sitemapConfig.schedule,
+    resolve: path.resolve(
+      import.meta.dirname,
+      'services',
+      'sitemap',
+      'generateSitemapJob.js'
+    ),
+    enabled: sitemapConfig.enabled
   });
 };

--- a/packages/evershop/src/modules/base/pages/frontStore/all/serveSitemap.ts
+++ b/packages/evershop/src/modules/base/pages/frontStore/all/serveSitemap.ts
@@ -1,0 +1,113 @@
+import { getBaseUrl } from '../../../../../lib/util/getBaseUrl.js';
+import { EvershopRequest } from '../../../../../types/request.js';
+import { EvershopResponse } from '../../../../../types/response.js';
+import { getSetting } from '../../../../setting/services/setting.js';
+import { SitemapConfig, getSitemapConfig } from '../../../services/sitemap/config.js';
+import { ensureSitemap } from '../../../services/sitemap/ensureSitemap.js';
+import { renderRobotsTxt } from '../../../services/sitemap/render/renderRobotsTxt.js';
+
+/** Root-level sitemap files: `/sitemap.xml`, `/sitemap-products.xml`, … (design §5/§12 C4). */
+const SITEMAP_FILE_RE = /^\/sitemap(-[a-z0-9-]+)?\.xml$/;
+
+/**
+ * Injectable dependencies, so the handler is unit-testable without a DB / real fs.
+ */
+export interface ServeSitemapDeps {
+  ensureSitemap: (fileName: string) => Promise<Buffer | null>;
+  getConfig: () => SitemapConfig;
+  /** The `robotsTxt` setting override, or null when unset. */
+  getRobotsOverride: () => Promise<string | null>;
+  getBaseUrl: () => string;
+}
+
+/**
+ * Cold-path handler for `/sitemap.xml`, `/sitemap-*.xml` and `/robots.txt`. Fires only on a
+ * would-be-404 — when a physical `public/` file exists, `publicStatic` already served it and we
+ * never run (wiki/sitemap-design.md §2). Matches the canonical locale-stripped path so
+ * `/de/sitemap.xml` resolves too. Active (3-arg): sends the response and returns without `next()`,
+ * or calls `next()` to fall through to the 404.
+ */
+export async function serveSitemapRequest(
+  request: EvershopRequest,
+  response: EvershopResponse,
+  next: (err?: unknown) => void,
+  deps: ServeSitemapDeps
+): Promise<void> {
+  // Only would-be-404s; a request that matched a real route is left alone.
+  if ((request as unknown as { currentRoute?: { id?: string } }).currentRoute?.id !== 'notFound') {
+    next();
+    return;
+  }
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    next();
+    return;
+  }
+
+  const path =
+    (request as unknown as { localePath?: string }).localePath ??
+    request.originalUrl.split('?')[0];
+  const config = deps.getConfig();
+
+  try {
+    if (SITEMAP_FILE_RE.test(path)) {
+      if (!config.enabled) {
+        next();
+        return;
+      }
+      const buffer = await deps.ensureSitemap(path.slice(1)); // strip leading '/'
+      if (!buffer) {
+        // A sitemap-shaped path that generation doesn't produce ⇒ let it 404.
+        next();
+        return;
+      }
+      // Override the 404 the notFound classification already set on the response.
+      response.status(200);
+      response.set('Content-Type', 'application/xml; charset=utf-8');
+      response.set('Cache-Control', 'public, max-age=3600');
+      response.send(buffer);
+      return;
+    }
+
+    if (path === '/robots.txt') {
+      if (!config.robots.enabled) {
+        next();
+        return;
+      }
+      const override = await deps.getRobotsOverride();
+      const body =
+        override ??
+        renderRobotsTxt({
+          sitemapUrl: `${deps.getBaseUrl()}/sitemap.xml`,
+          disallow: config.robots.disallow,
+          // Don't advertise a sitemap that won't be generated.
+          includeSitemap: config.enabled
+        });
+      // Override the 404 the notFound classification already set on the response.
+      response.status(200);
+      response.set('Content-Type', 'text/plain; charset=utf-8');
+      response.set('Cache-Control', 'public, max-age=3600');
+      response.send(body);
+      return;
+    }
+
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+const defaultDeps: ServeSitemapDeps = {
+  ensureSitemap: (fileName) => ensureSitemap(fileName),
+  getConfig: getSitemapConfig,
+  getBaseUrl,
+  getRobotsOverride: async () => {
+    const value = await getSetting<unknown>('robotsTxt', '');
+    return typeof value === 'string' && value.trim() ? value : null;
+  }
+};
+
+export default async (
+  request: EvershopRequest,
+  response: EvershopResponse,
+  next: (err?: unknown) => void
+): Promise<void> => serveSitemapRequest(request, response, next, defaultDeps);

--- a/packages/evershop/src/modules/base/pages/frontStore/all/tests/unit/serveSitemap.test.ts
+++ b/packages/evershop/src/modules/base/pages/frontStore/all/tests/unit/serveSitemap.test.ts
@@ -1,0 +1,264 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { getSitemapConfig } from '../../../../../services/sitemap/config.js';
+import { ensureSitemap } from '../../../../../services/sitemap/ensureSitemap.js';
+import { createLocalSitemapStorage } from '../../../../../services/sitemap/storage.js';
+import { SitemapCollector } from '../../../../../services/sitemap/types.js';
+import {
+  ServeSitemapDeps,
+  serveSitemapRequest
+} from '../../serveSitemap.js';
+
+function makeReq(over: Record<string, unknown> = {}): any {
+  return {
+    method: 'GET',
+    originalUrl: '/sitemap.xml',
+    currentRoute: { id: 'notFound' },
+    ...over
+  };
+}
+
+function makeRes(): any {
+  const headers: Record<string, string> = {};
+  const res: any = {
+    headers,
+    body: undefined,
+    statusCode: undefined,
+    status: jest.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    set: jest.fn((key: string, value: string) => {
+      headers[key] = value;
+      return res;
+    }),
+    send: jest.fn((body: unknown) => {
+      res.body = body;
+      return res;
+    })
+  };
+  return res;
+}
+
+function makeDeps(over: Partial<ServeSitemapDeps> = {}): ServeSitemapDeps {
+  return {
+    ensureSitemap: jest.fn(async () => Buffer.from('<sitemapindex/>')),
+    getConfig: () => getSitemapConfig(),
+    getRobotsOverride: async () => null,
+    getBaseUrl: () => 'https://shop.com',
+    ...over
+  };
+}
+
+describe('serveSitemapRequest — gating', () => {
+  it('passes through when the request matched a real route', async () => {
+    const req = makeReq({ currentRoute: { id: 'productView' } });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps());
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('passes through for non-GET/HEAD methods', async () => {
+    const req = makeReq({ method: 'POST', originalUrl: '/sitemap.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps());
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('passes through for an unrelated 404 path', async () => {
+    const req = makeReq({ originalUrl: '/nope' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps());
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('serveSitemapRequest — sitemap files', () => {
+  it('serves /sitemap.xml as application/xml and does not call next', async () => {
+    const ensure = jest.fn(async () => Buffer.from('<sitemapindex/>'));
+    const req = makeReq({ originalUrl: '/sitemap.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps({ ensureSitemap: ensure }));
+    expect(ensure).toHaveBeenCalledWith('sitemap.xml');
+    expect(res.statusCode).toBe(200); // overrides the notFound 404
+    expect(res.headers['Content-Type']).toBe('application/xml; charset=utf-8');
+    expect(res.send).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('serves a child file by its full name', async () => {
+    const ensure = jest.fn(async () => Buffer.from('<urlset/>'));
+    const req = makeReq({ originalUrl: '/sitemap-products.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps({ ensureSitemap: ensure }));
+    expect(ensure).toHaveBeenCalledWith('sitemap-products.xml');
+    expect(res.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to 404 when generation does not produce the file', async () => {
+    const req = makeReq({ originalUrl: '/sitemap-unknown.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(
+      req,
+      res,
+      next,
+      makeDeps({ ensureSitemap: async () => null })
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('passes through sitemap files when the feature is disabled', async () => {
+    const req = makeReq({ originalUrl: '/sitemap.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(
+      req,
+      res,
+      next,
+      makeDeps({ getConfig: () => ({ ...getSitemapConfig(), enabled: false }) })
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a generation error via next(err)', async () => {
+    const boom = new Error('boom');
+    const req = makeReq({ originalUrl: '/sitemap.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(
+      req,
+      res,
+      next,
+      makeDeps({
+        ensureSitemap: async () => {
+          throw boom;
+        }
+      })
+    );
+    expect(next).toHaveBeenCalledWith(boom);
+  });
+});
+
+describe('serveSitemapRequest — robots.txt', () => {
+  it('serves a dynamic default with an absolute Sitemap line', async () => {
+    const req = makeReq({ originalUrl: '/robots.txt' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps());
+    expect(res.statusCode).toBe(200); // overrides the notFound 404
+    expect(res.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+    const body = res.body as string;
+    expect(body).toContain('User-agent: *');
+    expect(body).toContain('Disallow: /admin/');
+    expect(body).toContain('Sitemap: https://shop.com/sitemap.xml');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('serves the robotsTxt setting override verbatim (setting > default)', async () => {
+    const req = makeReq({ originalUrl: '/robots.txt' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(
+      req,
+      res,
+      next,
+      makeDeps({ getRobotsOverride: async () => 'User-agent: *\nDisallow: /secret' })
+    );
+    expect(res.body).toBe('User-agent: *\nDisallow: /secret');
+    expect(res.body).not.toContain('/admin/');
+  });
+
+  it('omits the Sitemap line when the feature is disabled', async () => {
+    const req = makeReq({ originalUrl: '/robots.txt' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(
+      req,
+      res,
+      next,
+      makeDeps({ getConfig: () => ({ ...getSitemapConfig(), enabled: false }) })
+    );
+    expect(res.body as string).not.toContain('Sitemap:');
+    expect(res.body as string).toContain('Disallow: /admin/');
+  });
+
+  it('passes through when robots is disabled', async () => {
+    const req = makeReq({ originalUrl: '/robots.txt' });
+    const res = makeRes();
+    const next = jest.fn();
+    const config = getSitemapConfig();
+    await serveSitemapRequest(req, res, next, makeDeps({
+      getConfig: () => ({ ...config, robots: { ...config.robots, enabled: false } })
+    }));
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('matches the canonical path for a locale-prefixed request (/de/robots.txt)', async () => {
+    // The locale middleware strips the prefix into request.localePath.
+    const req = makeReq({ originalUrl: '/de/robots.txt', localePath: '/robots.txt' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, makeDeps());
+    expect(res.body as string).toContain('Sitemap: https://shop.com/sitemap.xml');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('serveSitemapRequest — integration (real ensureSitemap + temp storage)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sitemap-serve-'));
+  });
+
+  it('generates on a cold cache and serves the real index bytes', async () => {
+    const storage = createLocalSitemapStorage({
+      publicDir: path.join(dir, 'public'),
+      cacheDir: path.join(dir, 'cache')
+    });
+    const collector: SitemapCollector = {
+      name: 'products',
+      async collect() {
+        return [{ path: '/a', lastmod: '2026-01-01T00:00:00.000Z' }];
+      },
+      async getFingerprint() {
+        return { count: 1, maxUpdatedAt: '2026-01-01T00:00:00.000Z' };
+      }
+    };
+    const deps = makeDeps({
+      ensureSitemap: (fileName) =>
+        ensureSitemap(fileName, {
+          storage,
+          collectors: [collector],
+          config: getSitemapConfig(),
+          baseUrl: 'https://shop.com',
+          locales: ['en'],
+          defaultLocale: 'en',
+          clock: () => 1
+        })
+    });
+
+    const req = makeReq({ originalUrl: '/sitemap.xml' });
+    const res = makeRes();
+    const next = jest.fn();
+    await serveSitemapRequest(req, res, next, deps);
+
+    const body = (res.body as Buffer).toString();
+    expect(body).toContain('<sitemapindex');
+    expect(body).toContain('https://shop.com/sitemap-products.xml');
+    expect(await storage.fileExists('sitemap-products.xml')).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/chunk.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/chunk.ts
@@ -1,0 +1,31 @@
+import { SitemapUrlRecord } from './types.js';
+
+/** A chunk of a collector's URLs destined for one child file, `sitemap-<name>.xml`. */
+export interface SitemapChunk {
+  name: string;
+  records: SitemapUrlRecord[];
+}
+
+/**
+ * Split a collector's POST-EXPANSION records into child sitemaps of at most `max` URLs each
+ * (Google's cap: 50,000 URLs / 50 MB per file). The first chunk keeps the base name; overflow
+ * chunks get `-2`, `-3`, … (`products`, `products-2`, …). Zero records ⇒ no chunk (the collector
+ * contributes no child and no index entry).
+ */
+export function chunk(
+  records: SitemapUrlRecord[],
+  max: number,
+  baseName: string
+): SitemapChunk[] {
+  if (records.length === 0) {
+    return [];
+  }
+  const size = max > 0 ? max : records.length;
+  const chunks: SitemapChunk[] = [];
+  for (let offset = 0; offset < records.length; offset += size) {
+    const index = offset / size;
+    const name = index === 0 ? baseName : `${baseName}-${index + 1}`;
+    chunks.push({ name, records: records.slice(offset, offset + size) });
+  }
+  return chunks;
+}

--- a/packages/evershop/src/modules/base/services/sitemap/collectors/builtins.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/collectors/builtins.ts
@@ -1,0 +1,61 @@
+import { SitemapConfig, getSitemapConfig } from '../config.js';
+import { SitemapCollector } from '../types.js';
+import { createEntityCollector } from './entityCollector.js';
+import { createStaticCollector } from './staticCollector.js';
+
+/**
+ * The five built-in collectors, assembled from config. Registered at bootstrap (P5). Enumeration
+ * rules and status filters per design §3.3:
+ *  - products      status = true AND visibility = true
+ *  - categories    status = true                       (menu visibility is NOT a gate)
+ *  - cms-pages     status = true                       (default NULL ⇒ unpublished excluded)
+ *  - landing-pages status = true AND within the publish window (NULL bounds ⇒ open-ended)
+ *  - static        config `staticPaths` (default `/`)
+ *
+ * Collector `name`s double as child-file basenames (`sitemap-<name>.xml`), so they stay URL-safe.
+ */
+export function getBuiltinSitemapCollectors(
+  config: SitemapConfig = getSitemapConfig()
+): SitemapCollector[] {
+  const { changefreq, priority } = config;
+  return [
+    createEntityCollector({
+      name: 'products',
+      table: 'product',
+      entityType: 'product',
+      where: 'e.status = true AND e.visibility = true',
+      changefreq: changefreq.product,
+      priority: priority.product
+    }),
+    createEntityCollector({
+      name: 'categories',
+      table: 'category',
+      entityType: 'category',
+      where: 'e.status = true',
+      changefreq: changefreq.category,
+      priority: priority.category
+    }),
+    createEntityCollector({
+      name: 'cms-pages',
+      table: 'cms_page',
+      entityType: 'cms_page',
+      where: 'e.status = true',
+      changefreq: changefreq.cmsPage,
+      priority: priority.cmsPage
+    }),
+    createEntityCollector({
+      name: 'landing-pages',
+      table: 'landing_page',
+      entityType: 'landing_page',
+      where:
+        'e.status = true AND COALESCE(e.publish_start, NOW()) <= NOW() AND COALESCE(e.publish_end, NOW()) >= NOW()',
+      changefreq: changefreq.landingPage,
+      priority: priority.landingPage
+    }),
+    createStaticCollector({
+      paths: config.staticPaths,
+      changefreq: changefreq.static,
+      priority: priority.static
+    })
+  ];
+}

--- a/packages/evershop/src/modules/base/services/sitemap/collectors/entityCollector.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/collectors/entityCollector.ts
@@ -1,0 +1,80 @@
+import { pool } from '../../../../../lib/postgres/connection.js';
+import {
+  CollectorStat,
+  SitemapChangeFreq,
+  SitemapCollector,
+  SitemapEntry
+} from '../types.js';
+import { EntityUrlRow, mapEntityRows } from './mappers.js';
+
+/**
+ * Spec for a DB-backed collector over any entity that has `url_rewrite` rows. `table`,
+ * `entityType`, `where` and `updatedAtColumn` are TRUSTED CONSTANTS (never user input) —
+ * `entityType` is bound as a parameter; the rest are interpolated.
+ */
+export interface EntityCollectorSpec {
+  name: string;
+  table: string;
+  entityType: string;
+  /** SQL boolean expression over the entity alias `e` (e.g. `e.status = 1`). Default: all rows. */
+  where?: string;
+  /** Timestamp column on the entity for `<lastmod>`. Default `updated_at`; some tables use `created_at`. */
+  updatedAtColumn?: string;
+  changefreq?: SitemapChangeFreq;
+  priority?: number;
+}
+
+/**
+ * Build a collector that enumerates an entity's live friendly URLs by joining it to
+ * `url_rewrite` (design §3.3). `collect()` reads `request_path` + `updated_at`; `getFingerprint()`
+ * runs the SAME join/filter as a `count`/`max(updated_at)` so the change signal tracks exactly the
+ * collected set.
+ */
+export function createEntityCollector(spec: EntityCollectorSpec): SitemapCollector {
+  const { name, table, entityType, changefreq, priority } = spec;
+  const where = spec.where ?? 'true';
+  const updatedAt = spec.updatedAtColumn ?? 'updated_at';
+  // Shared FROM/JOIN/WHERE. `ur.entity_type` bound as $1; the rest are trusted constants.
+  const source = `FROM "${table}" e JOIN url_rewrite ur ON ur.entity_uuid = e.uuid AND ur.entity_type = $1 WHERE ${where}`;
+
+  return {
+    name,
+    async collect(): Promise<SitemapEntry[]> {
+      const result = await pool.query(
+        `SELECT ur.request_path AS request_path, e.${updatedAt} AS updated_at ${source}`,
+        [entityType]
+      );
+      return mapEntityRows(result.rows as EntityUrlRow[], { changefreq, priority });
+    },
+    async getFingerprint(): Promise<CollectorStat> {
+      // `paths_hash` hashes the actual request_paths (order-independent), so a URL change that
+      // leaves `updated_at` untouched still moves the fingerprint. `md5(string_agg(...))` is null
+      // when there are no rows.
+      const result = await pool.query(
+        `SELECT count(*)::int AS count,
+                max(e.${updatedAt}) AS max_updated_at,
+                md5(string_agg(ur.request_path, ',' ORDER BY ur.request_path)) AS paths_hash
+         ${source}`,
+        [entityType]
+      );
+      const row = (result.rows[0] as {
+        count: number;
+        max_updated_at: unknown;
+        paths_hash: string | null;
+      }) ?? { count: 0, max_updated_at: null, paths_hash: null };
+      return {
+        count: Number(row.count) || 0,
+        maxUpdatedAt: toIsoOrNull(row.max_updated_at),
+        pathsHash: row.paths_hash ?? null
+      };
+    }
+  };
+}
+
+function toIsoOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}

--- a/packages/evershop/src/modules/base/services/sitemap/collectors/mappers.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/collectors/mappers.ts
@@ -1,0 +1,75 @@
+import { SitemapChangeFreq, SitemapEntry } from '../types.js';
+
+/**
+ * Pure row → `SitemapEntry` mappers shared by the DB-backed collectors. Kept separate from the
+ * collectors themselves (which query the pool) so the mapping logic is unit-tested without a DB.
+ * All entity collectors JOIN `url_rewrite`, so their rows share this shape (design §3.3).
+ */
+
+export interface EntityUrlRow {
+  /** `url_rewrite.request_path` — the canonical friendly path. */
+  request_path: string;
+  /** The entity's `updated_at` (drives `<lastmod>`). */
+  updated_at: string | Date | null;
+}
+
+export interface MapEntityOptions {
+  changefreq?: SitemapChangeFreq;
+  priority?: number;
+}
+
+/** Map DB rows (entity JOIN url_rewrite) to canonical sitemap entries. Rows without a path are skipped. */
+export function mapEntityRows(
+  rows: EntityUrlRow[],
+  options: MapEntityOptions = {}
+): SitemapEntry[] {
+  const entries: SitemapEntry[] = [];
+  for (const row of rows) {
+    if (typeof row.request_path !== 'string' || row.request_path.length === 0) {
+      continue;
+    }
+    const entry: SitemapEntry = { path: row.request_path };
+    const lastmod = toIso(row.updated_at);
+    if (lastmod) entry.lastmod = lastmod;
+    if (options.changefreq !== undefined) entry.changefreq = options.changefreq;
+    if (options.priority !== undefined) entry.priority = options.priority;
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/** A configured static path (e.g. the homepage `/`). */
+export interface StaticPathSpec {
+  path: string;
+  lastmod?: string;
+  changefreq?: SitemapChangeFreq;
+  priority?: number;
+}
+
+/** Map configured static paths to entries. Non-root-relative paths are skipped. */
+export function mapStaticPaths(specs: StaticPathSpec[]): SitemapEntry[] {
+  const entries: SitemapEntry[] = [];
+  for (const spec of specs) {
+    if (typeof spec.path !== 'string' || !spec.path.startsWith('/')) {
+      continue;
+    }
+    const entry: SitemapEntry = { path: spec.path };
+    if (spec.lastmod !== undefined) entry.lastmod = spec.lastmod;
+    if (spec.changefreq !== undefined) entry.changefreq = spec.changefreq;
+    if (spec.priority !== undefined) entry.priority = spec.priority;
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/** Coerce a DB timestamp to an ISO-8601 string, or undefined when absent/invalid. */
+function toIso(value: string | Date | null | undefined): string | undefined {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString();
+}

--- a/packages/evershop/src/modules/base/services/sitemap/collectors/staticCollector.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/collectors/staticCollector.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'crypto';
+import {
+  CollectorStat,
+  SitemapChangeFreq,
+  SitemapCollector,
+  SitemapEntry
+} from '../types.js';
+import { StaticPathSpec, mapStaticPaths } from './mappers.js';
+
+export interface StaticCollectorSpec {
+  paths: string[];
+  changefreq?: SitemapChangeFreq;
+  priority?: number;
+  name?: string;
+}
+
+/**
+ * A config-driven collector for fixed storefront paths (default just the homepage `/`). No DB.
+ * The fingerprint is the path count — a config change that alters the count (add/remove a path)
+ * triggers a regenerate; a same-count swap is picked up by the max-age backstop (design §4).
+ */
+export function createStaticCollector(spec: StaticCollectorSpec): SitemapCollector {
+  const name = spec.name ?? 'static';
+  const specs: StaticPathSpec[] = spec.paths.map((path) => ({
+    path,
+    changefreq: spec.changefreq,
+    priority: spec.priority
+  }));
+  return {
+    name,
+    async collect(): Promise<SitemapEntry[]> {
+      return mapStaticPaths(specs);
+    },
+    async getFingerprint(): Promise<CollectorStat> {
+      const paths = mapStaticPaths(specs).map((entry) => entry.path);
+      return {
+        count: paths.length,
+        maxUpdatedAt: null,
+        // Hash the paths so changing `staticPaths` in config (add/remove/swap) triggers a regen.
+        pathsHash: paths.length
+          ? createHash('md5').update([...paths].sort().join(',')).digest('hex')
+          : null
+      };
+    }
+  };
+}

--- a/packages/evershop/src/modules/base/services/sitemap/config.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/config.ts
@@ -1,0 +1,81 @@
+import config from 'config';
+import { SitemapChangeFreq } from './types.js';
+
+/**
+ * Resolved sitemap configuration. Read from node-config under the `sitemap` namespace with the
+ * defaults below as fallback, so it works identically before and after P5 registers the module
+ * defaults (`config.util.setModuleDefaults('sitemap', …)`) — a cold config (unit test, fresh
+ * install) yields exactly these defaults. Read via the raw `config` package (not the typed
+ * `getConfig`) until the `sitemap` key is added to `ConfigStructure` in P5.
+ */
+export interface SitemapConfig {
+  enabled: boolean;
+  schedule: string;
+  maxUrlsPerFile: number;
+  /** ms; force a full regenerate when the last one is older than this, regardless of fingerprint. */
+  maxAge: number;
+  hreflang: boolean;
+  staticPaths: string[];
+  changefreq: {
+    product: SitemapChangeFreq;
+    category: SitemapChangeFreq;
+    cmsPage: SitemapChangeFreq;
+    landingPage: SitemapChangeFreq;
+    static: SitemapChangeFreq;
+  };
+  priority: {
+    product: number;
+    category: number;
+    cmsPage: number;
+    landingPage: number;
+    static: number;
+  };
+  robots: { enabled: boolean; disallow: string[] };
+}
+
+export const SITEMAP_CONFIG_DEFAULTS: SitemapConfig = {
+  enabled: true,
+  schedule: '*/30 * * * *',
+  maxUrlsPerFile: 50000,
+  maxAge: 24 * 60 * 60 * 1000,
+  hreflang: true,
+  staticPaths: ['/'],
+  changefreq: {
+    product: 'daily',
+    category: 'daily',
+    cmsPage: 'weekly',
+    landingPage: 'weekly',
+    static: 'daily'
+  },
+  priority: {
+    product: 0.7,
+    category: 0.8,
+    cmsPage: 0.5,
+    landingPage: 0.6,
+    static: 1.0
+  },
+  robots: {
+    enabled: true,
+    disallow: ['/admin/', '/checkout', '/account', '/cart', '/api/']
+  }
+};
+
+function read<T>(key: string, fallback: T): T {
+  return config.has(key) ? (config.get(key) as T) : fallback;
+}
+
+/** Resolve the effective sitemap config (defaults merged with any `sitemap.*` overrides). */
+export function getSitemapConfig(): SitemapConfig {
+  const d = SITEMAP_CONFIG_DEFAULTS;
+  return {
+    enabled: read('sitemap.enabled', d.enabled),
+    schedule: read('sitemap.schedule', d.schedule),
+    maxUrlsPerFile: read('sitemap.maxUrlsPerFile', d.maxUrlsPerFile),
+    maxAge: read('sitemap.maxAge', d.maxAge),
+    hreflang: read('sitemap.hreflang', d.hreflang),
+    staticPaths: read('sitemap.staticPaths', d.staticPaths),
+    changefreq: { ...d.changefreq, ...read('sitemap.changefreq', {}) },
+    priority: { ...d.priority, ...read('sitemap.priority', {}) },
+    robots: { ...d.robots, ...read('sitemap.robots', {}) }
+  };
+}

--- a/packages/evershop/src/modules/base/services/sitemap/ensureSitemap.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/ensureSitemap.ts
@@ -1,0 +1,20 @@
+import { GenerateOptions, generateSitemap } from './generateSitemap.js';
+import { SitemapStorage, getSitemapStorage } from './storage.js';
+
+/**
+ * Cold-path helper for the serve middleware: return the requested sitemap file, generating the
+ * whole set first if it's missing (first boot, or after a cache wipe). Returns `null` for a name
+ * that generation doesn't produce (unknown child) so the caller can fall through to a 404.
+ * Single-flight-aware via `generateSitemap`.
+ */
+export async function ensureSitemap(
+  fileName: string,
+  options: GenerateOptions = {}
+): Promise<Buffer | null> {
+  const storage: SitemapStorage = options.storage ?? getSitemapStorage();
+  if (await storage.fileExists(fileName)) {
+    return storage.readFile(fileName);
+  }
+  await generateSitemap({ ...options, storage, force: true });
+  return storage.readFile(fileName);
+}

--- a/packages/evershop/src/modules/base/services/sitemap/expandLocales.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/expandLocales.ts
@@ -1,0 +1,98 @@
+import { applyLocalePrefix } from '../../../../lib/locale/activeDictionary.js';
+import { SitemapAlternate, SitemapEntry, SitemapUrlRecord } from './types.js';
+
+export interface ExpandLocalesOptions {
+  /** Enabled storefront locales, default first (from `getEnabledLanguages()`). */
+  locales: string[];
+  /** The default/unprefixed locale (from `getStoreLanguage()`). */
+  defaultLocale: string;
+  /** Absolute origin, no trailing slash (from `getBaseUrl()`). */
+  baseUrl: string;
+  /** Emit `<xhtml:link>` alternates on multi-locale stores. Default true. */
+  hreflang?: boolean;
+}
+
+/**
+ * Fan each canonical `SitemapEntry` out into one absolute, localized `SitemapUrlRecord` per
+ * enabled locale (wiki/sitemap-design.md §3.4).
+ *
+ * EverShop serves every enabled locale on a shared slug via URL prefix — the default locale
+ * unprefixed (`/shoes`), each non-default enabled locale prefixed (`/de/shoes`). Localization
+ * REUSES the storefront's own `applyLocalePrefix`, so sitemap URLs can't drift from what the
+ * router serves. On multi-locale stores (and unless `hreflang` is false) every record carries
+ * the full self-referential hreflang set — one entry per enabled locale INCLUDING ITSELF, plus
+ * `x-default` → the default-locale URL — which makes the reciprocity Google requires hold by
+ * construction. Single-language stores emit one record per entry with no alternates.
+ */
+export function expandLocales(
+  entries: SitemapEntry[],
+  options: ExpandLocalesOptions
+): SitemapUrlRecord[] {
+  const { defaultLocale, baseUrl } = options;
+  const locales = options.locales.length > 0 ? options.locales : [defaultLocale];
+  const withHreflang = options.hreflang !== false && locales.length > 1;
+
+  const records: SitemapUrlRecord[] = [];
+  for (const entry of entries) {
+    // The alternate set is identical for every locale variant of this entry, so compute once.
+    const alternates = withHreflang
+      ? buildAlternates(entry.path, locales, defaultLocale, baseUrl)
+      : undefined;
+
+    for (const locale of locales) {
+      const record: SitemapUrlRecord = {
+        loc: toAbsolute(entry.path, locale, defaultLocale, baseUrl)
+      };
+      if (entry.lastmod !== undefined) record.lastmod = entry.lastmod;
+      if (entry.changefreq !== undefined) record.changefreq = entry.changefreq;
+      if (entry.priority !== undefined) record.priority = entry.priority;
+      if (alternates) record.alternates = alternates;
+      records.push(record);
+    }
+  }
+  return records;
+}
+
+function buildAlternates(
+  path: string,
+  locales: string[],
+  defaultLocale: string,
+  baseUrl: string
+): SitemapAlternate[] {
+  const alternates = locales.map((locale) => ({
+    hreflang: toHreflang(locale),
+    href: toAbsolute(path, locale, defaultLocale, baseUrl)
+  }));
+  alternates.push({
+    hreflang: 'x-default',
+    href: toAbsolute(path, defaultLocale, defaultLocale, baseUrl)
+  });
+  return alternates;
+}
+
+/** Build the absolute, locale-localized URL for a canonical path. Already-absolute paths pass through. */
+function toAbsolute(
+  path: string,
+  locale: string,
+  defaultLocale: string,
+  baseUrl: string
+): string {
+  if (isAbsolute(path)) {
+    return path;
+  }
+  const localized = applyLocalePrefix(path, {
+    locale,
+    defaultLocale,
+    isAdmin: false
+  });
+  return `${baseUrl}${localized}`;
+}
+
+function isAbsolute(path: string): boolean {
+  return /^https?:\/\//i.test(path);
+}
+
+/** hreflang wants BCP-47 (hyphen); EverShop locale codes are already lowercased. */
+function toHreflang(locale: string): string {
+  return locale.replace(/_/g, '-');
+}

--- a/packages/evershop/src/modules/base/services/sitemap/fingerprint.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/fingerprint.ts
@@ -1,0 +1,41 @@
+import { CollectorStat } from './types.js';
+
+/** One collector's contribution to the fingerprint. */
+export interface FingerprintEntry {
+  name: string;
+  stat: CollectorStat;
+}
+
+/**
+ * Build a deterministic change-fingerprint for the whole sitemap (wiki/sitemap-design.md §4).
+ *
+ * Folds in each collector's `(count, maxUpdatedAt, pathsHash)` PLUS the enabled-locale set and
+ * default locale. `pathsHash` catches URL changes that don't bump `updated_at` (category
+ * assign/move/reparent, the async `url_rewrite` rebuild); the locale part catches language
+ * changes that alter every URL with no entity change. Entries and locales are sorted so the
+ * result is independent of registration/iteration order.
+ */
+export function buildFingerprint(
+  entries: FingerprintEntry[],
+  locales: string[],
+  defaultLocale: string
+): string {
+  const localePart = `locales:${[...locales]
+    .sort()
+    .join(',')}|default:${defaultLocale}`;
+  const statPart = [...entries]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(
+      (entry) =>
+        `${entry.name}:${entry.stat.count}:${entry.stat.maxUpdatedAt ?? ''}:${
+          entry.stat.pathsHash ?? ''
+        }`
+    )
+    .join('|');
+  return `${localePart}|${statPart}`;
+}
+
+/** True when the sitemap must be regenerated (no prior fingerprint, or it moved). */
+export function hasChanged(previous: string | null, next: string): boolean {
+  return previous !== next;
+}

--- a/packages/evershop/src/modules/base/services/sitemap/generateSitemap.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/generateSitemap.ts
@@ -1,0 +1,192 @@
+import { getBaseUrl } from '../../../../lib/util/getBaseUrl.js';
+import {
+  getEnabledLanguages,
+  getStoreLanguage
+} from '../../../setting/services/setting.js';
+import { chunk } from './chunk.js';
+import { SitemapConfig, getSitemapConfig } from './config.js';
+import { expandLocales } from './expandLocales.js';
+import {
+  FingerprintEntry,
+  buildFingerprint,
+  hasChanged
+} from './fingerprint.js';
+import { getSitemapCollectors } from './registry.js';
+import { renderIndex } from './render/renderIndex.js';
+import { renderUrlset } from './render/renderUrlset.js';
+import { SitemapStorage, getSitemapStorage } from './storage.js';
+import { SitemapCollector, SitemapUrlRecord } from './types.js';
+
+const INDEX_FILE = 'sitemap.xml';
+
+export interface GenerateOptions {
+  /** Rebuild even when the fingerprint is unchanged. */
+  force?: boolean;
+  // Dependency injection (defaults resolved from config / registry / settings). Used by tests
+  // and by callers that already hold these values.
+  collectors?: SitemapCollector[];
+  storage?: SitemapStorage;
+  config?: SitemapConfig;
+  baseUrl?: string;
+  locales?: string[];
+  defaultLocale?: string;
+  /** Epoch-ms clock (default `Date.now`) — injectable for deterministic tests. */
+  clock?: () => number;
+}
+
+export interface GenerateResult {
+  /** false ⇒ skipped because the fingerprint was unchanged and the cache is fresh. */
+  generated: boolean;
+  files: string[];
+  fingerprint: string;
+  urlCount: number;
+}
+
+// Single-flight: concurrent callers (cold-path thundering herd, or a request racing the cron)
+// share one in-progress generation instead of each launching their own. Per-process.
+let inflight: Promise<GenerateResult> | null = null;
+
+/**
+ * Generate the sitemap set (index + per-collector children) into storage, skipping the work when
+ * a cheap fingerprint shows nothing changed and the cache is fresh. See wiki/sitemap-design.md §2–§5.
+ */
+export function generateSitemap(
+  options: GenerateOptions = {}
+): Promise<GenerateResult> {
+  if (inflight) {
+    return inflight;
+  }
+  inflight = runGeneration(options).finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}
+
+async function runGeneration(
+  options: GenerateOptions
+): Promise<GenerateResult> {
+  const config = options.config ?? getSitemapConfig();
+  const storage = options.storage ?? getSitemapStorage();
+  const collectors = options.collectors ?? getSitemapCollectors();
+  const baseUrl = options.baseUrl ?? getBaseUrl();
+  const locales = options.locales ?? (await getEnabledLanguages());
+  const defaultLocale = options.defaultLocale ?? (await getStoreLanguage());
+  const now = options.clock ?? Date.now;
+
+  // --- Fingerprint (skip check) ---
+  const fpEntries: FingerprintEntry[] = [];
+  let canSkip = true;
+  for (const collector of collectors) {
+    if (typeof collector.getFingerprint === 'function') {
+      fpEntries.push({ name: collector.name, stat: await collector.getFingerprint() });
+    } else {
+      // A collector that can't summarise itself forces a full regenerate every run.
+      canSkip = false;
+    }
+  }
+  const fingerprint = buildFingerprint(fpEntries, locales, defaultLocale);
+
+  if (!options.force && canSkip) {
+    const meta = await storage.readMeta();
+    if (
+      meta &&
+      !hasChanged(meta.fingerprint, fingerprint) &&
+      withinMaxAge(meta.generatedAt, config.maxAge, now()) &&
+      (await allPresent(storage, meta.files))
+    ) {
+      return {
+        generated: false,
+        files: meta.files,
+        fingerprint,
+        urlCount: meta.urlCount
+      };
+    }
+  }
+
+  // --- Collect → expand → chunk → render ---
+  const children: { name: string; xml: string; lastmod?: string }[] = [];
+  let urlCount = 0;
+  for (const collector of collectors) {
+    const entries = await collector.collect();
+    if (entries.length === 0) {
+      continue;
+    }
+    const records = expandLocales(entries, {
+      locales,
+      defaultLocale,
+      baseUrl,
+      hreflang: config.hreflang
+    });
+    for (const part of chunk(records, config.maxUrlsPerFile, collector.name)) {
+      children.push({
+        name: part.name,
+        xml: renderUrlset(part.records),
+        lastmod: maxLastmod(part.records)
+      });
+      urlCount += part.records.length;
+    }
+  }
+
+  const indexXml = renderIndex(
+    children.map((child) => ({ name: child.name, lastmod: child.lastmod })),
+    baseUrl
+  );
+  const files = [
+    INDEX_FILE,
+    ...children.map((child) => `sitemap-${child.name}.xml`)
+  ];
+
+  // Write children first, then the index, then meta — so a crash mid-write never advertises a
+  // child that isn't on disk yet.
+  await storage.writeFiles([
+    ...children.map((child) => ({
+      name: `sitemap-${child.name}.xml`,
+      content: child.xml
+    })),
+    { name: INDEX_FILE, content: indexXml }
+  ]);
+  await storage.writeMeta({
+    fingerprint,
+    generatedAt: new Date(now()).toISOString(),
+    files,
+    urlCount
+  });
+  await storage.pruneOrphans(files);
+
+  return { generated: true, files, fingerprint, urlCount };
+}
+
+function withinMaxAge(
+  generatedAt: string,
+  maxAge: number,
+  nowMs: number
+): boolean {
+  const then = new Date(generatedAt).getTime();
+  if (Number.isNaN(then)) {
+    return false;
+  }
+  return nowMs - then < maxAge;
+}
+
+async function allPresent(
+  storage: SitemapStorage,
+  files: string[]
+): Promise<boolean> {
+  for (const file of files) {
+    if (!(await storage.fileExists(file))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** The newest `lastmod` in a chunk (ISO strings sort chronologically), or undefined if none. */
+function maxLastmod(records: SitemapUrlRecord[]): string | undefined {
+  let max: string | undefined;
+  for (const record of records) {
+    if (record.lastmod && (max === undefined || record.lastmod > max)) {
+      max = record.lastmod;
+    }
+  }
+  return max;
+}

--- a/packages/evershop/src/modules/base/services/sitemap/generateSitemapJob.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/generateSitemapJob.ts
@@ -1,0 +1,10 @@
+import { generateSitemap } from './generateSitemap.js';
+
+/**
+ * Cron entry point. Regenerates the sitemap when the change-fingerprint has moved (or the max-age
+ * backstop has elapsed) — a no-op otherwise. Registered as the `generateSitemap` job in
+ * `base/bootstrap.js`; the runner calls this default export with no arguments in the cron child.
+ */
+export default async function runSitemapJob(): Promise<void> {
+  await generateSitemap({ force: false });
+}

--- a/packages/evershop/src/modules/base/services/sitemap/index.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Public API of the sitemap feature (`@evershop/evershop/base/services/sitemap`).
+ *
+ * The sitemap lives in the `base` module, so the export path mirrors that. Extensions add their
+ * own URLs with `registerSitemapCollector` from a `bootstrap` file; `createEntityCollector` is the shortcut for
+ * any entity that has `url_rewrite` rows; `generateSitemap` is exposed for a programmatic
+ * "regenerate now".
+ */
+export * from './types.js';
+export { registerSitemapCollector, getSitemapCollectors } from './registry.js';
+export { createEntityCollector } from './collectors/entityCollector.js';
+export type { EntityCollectorSpec } from './collectors/entityCollector.js';
+export { createStaticCollector } from './collectors/staticCollector.js';
+export type { StaticCollectorSpec } from './collectors/staticCollector.js';
+export { generateSitemap } from './generateSitemap.js';
+export type { GenerateOptions, GenerateResult } from './generateSitemap.js';

--- a/packages/evershop/src/modules/base/services/sitemap/registry.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/registry.ts
@@ -1,0 +1,17 @@
+import { addProcessor, getValueSync } from '../../../../lib/util/registry.js';
+import { SitemapCollector } from './types.js';
+
+const REGISTRY_KEY = 'sitemapCollectors';
+
+/**
+ * Register a source of sitemap URLs. Call from a `bootstrap` file only — the registry locks
+ * after bootstrap. Core registers its built-ins here (P5); extensions add their own the same way.
+ */
+export function registerSitemapCollector(collector: SitemapCollector): void {
+  addProcessor<SitemapCollector[]>(REGISTRY_KEY, (list) => [...list, collector]);
+}
+
+/** The registered collectors, in registration order. */
+export function getSitemapCollectors(): SitemapCollector[] {
+  return getValueSync<SitemapCollector[]>(REGISTRY_KEY, [], {});
+}

--- a/packages/evershop/src/modules/base/services/sitemap/render/escapeXml.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/render/escapeXml.ts
@@ -1,0 +1,21 @@
+/**
+ * Entity-escape a value for inclusion in XML text/attribute content. Ported from the
+ * blog RSS feed (`modules/blog/pages/frontStore/blogRss/index.ts`). Google requires that
+ * "all tag values must be entity escaped".
+ */
+export function escapeXml(value: unknown): string {
+  return String(value ?? '').replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      default:
+        return '&quot;';
+    }
+  });
+}

--- a/packages/evershop/src/modules/base/services/sitemap/render/renderIndex.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/render/renderIndex.ts
@@ -1,0 +1,35 @@
+import { escapeXml } from './escapeXml.js';
+
+const SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+
+/** A child sitemap referenced by the index. `name` is the child basename (`sitemap-<name>.xml`). */
+export interface SitemapIndexChild {
+  name: string;
+  lastmod?: string;
+}
+
+/**
+ * Serialize a `<sitemapindex>` document. Child `<loc>`s are fully-qualified root-level URLs
+ * (`${baseUrl}/sitemap-<name>.xml`) — every sitemap file lives at the site root so Google's
+ * directory-scope rule doesn't restrict which URLs a child may list (wiki/sitemap-design.md §12/C4).
+ */
+export function renderIndex(
+  children: SitemapIndexChild[],
+  baseUrl: string
+): string {
+  const body = children
+    .map((child) => renderChild(child, baseUrl))
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="${SITEMAP_NS}">\n${body}${
+    body ? '\n' : ''
+  }</sitemapindex>\n`;
+}
+
+function renderChild(child: SitemapIndexChild, baseUrl: string): string {
+  const loc = `${baseUrl}/sitemap-${child.name}.xml`;
+  const lines = [`    <loc>${escapeXml(loc)}</loc>`];
+  if (child.lastmod) {
+    lines.push(`    <lastmod>${escapeXml(child.lastmod)}</lastmod>`);
+  }
+  return `  <sitemap>\n${lines.join('\n')}\n  </sitemap>`;
+}

--- a/packages/evershop/src/modules/base/services/sitemap/render/renderRobotsTxt.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/render/renderRobotsTxt.ts
@@ -1,0 +1,33 @@
+export interface RobotsTxtOptions {
+  /** Absolute URL of the sitemap index, e.g. `https://shop.com/sitemap.xml`. */
+  sitemapUrl: string;
+  /** Paths to disallow, e.g. `['/admin/', '/checkout', '/account', '/cart', '/api/']`. */
+  disallow: string[];
+  /**
+   * Whether to advertise the sitemap. Defaults to true. Set false when sitemap generation is
+   * disabled so robots.txt doesn't point at a `Sitemap:` that won't resolve.
+   */
+  includeSitemap?: boolean;
+}
+
+/**
+ * Render a default robots.txt. Served dynamically only when no physical `public/robots.txt`
+ * exists (that file, if present, wins). The `Sitemap:` directive carries an ABSOLUTE URL —
+ * a static file can't know the per-install origin, which is why robots.txt is dynamic.
+ */
+export function renderRobotsTxt(options: RobotsTxtOptions): string {
+  const includeSitemap = options.includeSitemap !== false;
+  const lines = ['User-agent: *'];
+  if (options.disallow.length === 0) {
+    lines.push('Disallow:');
+  } else {
+    for (const path of options.disallow) {
+      lines.push(`Disallow: ${path}`);
+    }
+  }
+  if (includeSitemap && options.sitemapUrl) {
+    lines.push('');
+    lines.push(`Sitemap: ${options.sitemapUrl}`);
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/packages/evershop/src/modules/base/services/sitemap/render/renderUrlset.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/render/renderUrlset.ts
@@ -1,0 +1,53 @@
+import { SitemapUrlRecord } from '../types.js';
+import { escapeXml } from './escapeXml.js';
+
+const SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+
+/**
+ * Serialize already-absolute `SitemapUrlRecord`s into a `<urlset>` document (sitemaps.org
+ * 0.9). The `xmlns:xhtml` namespace is declared ONLY when at least one record carries
+ * hreflang alternates, so single-language sitemaps stay namespace-free. Absolutization and
+ * locale prefixing happened upstream in `expandLocales` — this function is a pure serializer.
+ */
+export function renderUrlset(records: SitemapUrlRecord[]): string {
+  const hasAlternates = records.some(
+    (record) => record.alternates && record.alternates.length > 0
+  );
+  const open = hasAlternates
+    ? `<urlset xmlns="${SITEMAP_NS}" xmlns:xhtml="${XHTML_NS}">`
+    : `<urlset xmlns="${SITEMAP_NS}">`;
+  const body = records.map(renderUrl).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${open}\n${body}${
+    body ? '\n' : ''
+  }</urlset>\n`;
+}
+
+function renderUrl(record: SitemapUrlRecord): string {
+  const lines = [`    <loc>${escapeXml(record.loc)}</loc>`];
+  if (record.lastmod) {
+    lines.push(`    <lastmod>${escapeXml(record.lastmod)}</lastmod>`);
+  }
+  if (record.changefreq) {
+    lines.push(`    <changefreq>${escapeXml(record.changefreq)}</changefreq>`);
+  }
+  if (record.priority !== undefined) {
+    lines.push(`    <priority>${formatPriority(record.priority)}</priority>`);
+  }
+  if (record.alternates) {
+    for (const alt of record.alternates) {
+      lines.push(
+        `    <xhtml:link rel="alternate" hreflang="${escapeXml(
+          alt.hreflang
+        )}" href="${escapeXml(alt.href)}"/>`
+      );
+    }
+  }
+  return `  <url>\n${lines.join('\n')}\n  </url>`;
+}
+
+/** Clamp to [0,1] and render with one decimal (sitemap priority precision). */
+function formatPriority(priority: number): string {
+  const clamped = Math.max(0, Math.min(1, priority));
+  return clamped.toFixed(1);
+}

--- a/packages/evershop/src/modules/base/services/sitemap/storage.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/storage.ts
@@ -1,0 +1,114 @@
+import fsp from 'fs/promises';
+import path from 'path';
+import { CONSTANTS } from '../../../../lib/helpers.js';
+import { getValueSync } from '../../../../lib/util/registry.js';
+
+/** One file to write: a bare filename (e.g. `sitemap.xml`, `sitemap-products.xml`) + its content. */
+export interface SitemapFile {
+  name: string;
+  content: string;
+}
+
+/** Persisted generation metadata (cache sidecar, never web-served). */
+export interface SitemapMeta {
+  fingerprint: string;
+  generatedAt: string;
+  files: string[];
+  urlCount: number;
+}
+
+export interface SitemapStorage {
+  writeFiles(files: SitemapFile[]): Promise<void>;
+  readFile(name: string): Promise<Buffer | null>;
+  fileExists(name: string): Promise<boolean>;
+  readMeta(): Promise<SitemapMeta | null>;
+  writeMeta(meta: SitemapMeta): Promise<void>;
+  pruneOrphans(keep: string[]): Promise<void>;
+}
+
+/** Only files matching this are eligible for pruning — never touch a merchant's other public files. */
+const SITEMAP_FILE_RE = /^sitemap(-[a-z0-9-]+)?\.xml$/;
+
+/**
+ * Local-disk storage. Output files land flat in the project `public/` folder (served by
+ * `publicStatic` at `/sitemap.xml`, `/sitemap-*.xml` — root-level per Google's directory-scope
+ * rule, design §12/C4). Metadata lives in the non-web-served cache dir. Writes are atomic
+ * (tmp + rename, pid-scoped tmp name so concurrent processes don't clash). Dirs injectable for tests.
+ */
+export function createLocalSitemapStorage(options?: {
+  publicDir?: string;
+  cacheDir?: string;
+}): SitemapStorage {
+  const publicDir = options?.publicDir ?? CONSTANTS.PUBLICPATH;
+  const cacheDir = options?.cacheDir ?? path.join(CONSTANTS.CACHEPATH, 'sitemap');
+  const metaPath = path.join(cacheDir, 'meta.json');
+
+  async function atomicWrite(
+    filePath: string,
+    content: string | Buffer
+  ): Promise<void> {
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    const tmp = `${filePath}.${process.pid}.tmp`;
+    await fsp.writeFile(tmp, content);
+    await fsp.rename(tmp, filePath);
+  }
+
+  return {
+    async writeFiles(files) {
+      for (const file of files) {
+        await atomicWrite(path.join(publicDir, file.name), file.content);
+      }
+    },
+    async readFile(name) {
+      try {
+        return await fsp.readFile(path.join(publicDir, name));
+      } catch {
+        return null;
+      }
+    },
+    async fileExists(name) {
+      try {
+        return (await fsp.stat(path.join(publicDir, name))).isFile();
+      } catch {
+        return false;
+      }
+    },
+    async readMeta() {
+      try {
+        return JSON.parse(await fsp.readFile(metaPath, 'utf8')) as SitemapMeta;
+      } catch {
+        return null;
+      }
+    },
+    async writeMeta(meta) {
+      await atomicWrite(metaPath, JSON.stringify(meta, null, 2));
+    },
+    async pruneOrphans(keep) {
+      const keepSet = new Set(keep);
+      let entries: string[];
+      try {
+        entries = await fsp.readdir(publicDir);
+      } catch {
+        return;
+      }
+      await Promise.all(
+        entries.map(async (name) => {
+          if (SITEMAP_FILE_RE.test(name) && !keepSet.has(name)) {
+            await fsp.rm(path.join(publicDir, name), { force: true });
+          }
+        })
+      );
+    }
+  };
+}
+
+/** Default local storage (project `public/` + `.evershop/sitemap/`). */
+export const localSitemapStorage = createLocalSitemapStorage();
+
+/**
+ * The active storage, resolved through the registry so an extension (e.g. S3) can redirect output
+ * by registering a `sitemapStorage` processor. Defaults to local disk (design §9).
+ */
+export function getSitemapStorage(): SitemapStorage {
+  return getValueSync<SitemapStorage>('sitemapStorage', localSitemapStorage, {});
+}

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/chunk.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/chunk.test.ts
@@ -1,0 +1,44 @@
+import { chunk } from '../../chunk.js';
+import { SitemapUrlRecord } from '../../types.js';
+
+const records = (n: number): SitemapUrlRecord[] =>
+  Array.from({ length: n }, (_, i) => ({ loc: `https://shop.com/p${i}` }));
+
+describe('chunk', () => {
+  it('returns no chunks for empty input', () => {
+    expect(chunk([], 50000, 'products')).toEqual([]);
+  });
+
+  it('returns a single named chunk under the limit', () => {
+    const out = chunk(records(1), 50000, 'products');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('products');
+    expect(out[0].records).toHaveLength(1);
+  });
+
+  it('keeps one chunk exactly at the limit', () => {
+    const out = chunk(records(50000), 50000, 'products');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('products');
+    expect(out[0].records).toHaveLength(50000);
+  });
+
+  it('splits into overflow chunks past the limit with -N names', () => {
+    const out = chunk(records(50001), 50000, 'products');
+    expect(out).toHaveLength(2);
+    expect(out[0].name).toBe('products');
+    expect(out[0].records).toHaveLength(50000);
+    expect(out[1].name).toBe('products-2');
+    expect(out[1].records).toHaveLength(1);
+  });
+
+  it('names successive overflow chunks -2, -3, …', () => {
+    const out = chunk(records(7), 3, 'products');
+    expect(out.map((c) => c.name)).toEqual([
+      'products',
+      'products-2',
+      'products-3'
+    ]);
+    expect(out.map((c) => c.records.length)).toEqual([3, 3, 1]);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/config.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/config.test.ts
@@ -1,0 +1,59 @@
+import { SITEMAP_CONFIG_DEFAULTS, getSitemapConfig } from '../../config.js';
+
+describe('SITEMAP_CONFIG_DEFAULTS', () => {
+  // The constant is the source of truth for "the documented defaults" — independent of the
+  // ambient config directory (which a store can override).
+  it('documents the expected default values', () => {
+    expect(SITEMAP_CONFIG_DEFAULTS.enabled).toBe(true);
+    expect(SITEMAP_CONFIG_DEFAULTS.schedule).toBe('*/30 * * * *');
+    expect(SITEMAP_CONFIG_DEFAULTS.maxUrlsPerFile).toBe(50000);
+    expect(SITEMAP_CONFIG_DEFAULTS.maxAge).toBe(24 * 60 * 60 * 1000);
+    expect(SITEMAP_CONFIG_DEFAULTS.hreflang).toBe(true);
+    expect(SITEMAP_CONFIG_DEFAULTS.staticPaths).toEqual(['/']);
+  });
+
+  it('has sensible per-type changefreq / priority', () => {
+    expect(SITEMAP_CONFIG_DEFAULTS.changefreq.product).toBe('daily');
+    expect(SITEMAP_CONFIG_DEFAULTS.priority.static).toBe(1.0);
+    expect(SITEMAP_CONFIG_DEFAULTS.priority.category).toBe(0.8);
+    expect(SITEMAP_CONFIG_DEFAULTS.priority.product).toBe(0.7);
+  });
+
+  it('disallows the non-indexable areas in robots by default', () => {
+    expect(SITEMAP_CONFIG_DEFAULTS.robots.enabled).toBe(true);
+    expect(SITEMAP_CONFIG_DEFAULTS.robots.disallow).toEqual(
+      expect.arrayContaining(['/admin/', '/checkout', '/account', '/cart', '/api/'])
+    );
+  });
+});
+
+describe('getSitemapConfig', () => {
+  // Reads the ambient config directory with the defaults as fallback, so individual values may be
+  // overridden by config/*.json (e.g. a custom `sitemap.schedule`). We assert shape + types, which
+  // are robust to any override, rather than exact values.
+  it('returns a complete, well-typed config', () => {
+    const config = getSitemapConfig();
+    expect(typeof config.enabled).toBe('boolean');
+    expect(typeof config.schedule).toBe('string');
+    expect(typeof config.maxUrlsPerFile).toBe('number');
+    expect(typeof config.maxAge).toBe('number');
+    expect(typeof config.hreflang).toBe('boolean');
+    expect(Array.isArray(config.staticPaths)).toBe(true);
+    expect(Object.keys(config.changefreq).sort()).toEqual([
+      'category',
+      'cmsPage',
+      'landingPage',
+      'product',
+      'static'
+    ]);
+    expect(Object.keys(config.priority).sort()).toEqual([
+      'category',
+      'cmsPage',
+      'landingPage',
+      'product',
+      'static'
+    ]);
+    expect(typeof config.robots.enabled).toBe('boolean');
+    expect(Array.isArray(config.robots.disallow)).toBe(true);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/escapeXml.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/escapeXml.test.ts
@@ -1,0 +1,23 @@
+import { escapeXml } from '../../render/escapeXml.js';
+
+describe('escapeXml', () => {
+  it.each([
+    ['<', '&lt;'],
+    ['>', '&gt;'],
+    ['&', '&amp;'],
+    ["'", '&apos;'],
+    ['"', '&quot;']
+  ])('escapes %p', (input, expected) => {
+    expect(escapeXml(input)).toBe(expected);
+  });
+
+  it('escapes a combined string', () => {
+    expect(escapeXml(`a<b>c&d'e"f`)).toBe('a&lt;b&gt;c&amp;d&apos;e&quot;f');
+  });
+
+  it('coerces null / undefined / number', () => {
+    expect(escapeXml(null)).toBe('');
+    expect(escapeXml(undefined)).toBe('');
+    expect(escapeXml(42)).toBe('42');
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/expandLocales.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/expandLocales.test.ts
@@ -1,0 +1,121 @@
+import { expandLocales } from '../../expandLocales.js';
+import { SitemapEntry } from '../../types.js';
+
+const BASE = 'https://shop.com';
+const entry = (path: string, extra: Partial<SitemapEntry> = {}): SitemapEntry => ({
+  path,
+  ...extra
+});
+
+describe('expandLocales', () => {
+  describe('single-locale store', () => {
+    it('emits one unprefixed record per entry, no alternates', () => {
+      const out = expandLocales(
+        [entry('/shoes', { lastmod: '2026-01-01T00:00:00.000Z' })],
+        { locales: ['en'], defaultLocale: 'en', baseUrl: BASE }
+      );
+      expect(out).toHaveLength(1);
+      expect(out[0].loc).toBe('https://shop.com/shoes');
+      expect(out[0].lastmod).toBe('2026-01-01T00:00:00.000Z');
+      expect(out[0].alternates).toBeUndefined();
+    });
+
+    it('falls back to [defaultLocale] when locales is empty', () => {
+      const out = expandLocales([entry('/shoes')], {
+        locales: [],
+        defaultLocale: 'en',
+        baseUrl: BASE
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0].loc).toBe('https://shop.com/shoes');
+      expect(out[0].alternates).toBeUndefined();
+    });
+  });
+
+  describe('multi-locale store', () => {
+    const opts = { locales: ['en', 'de', 'fr'], defaultLocale: 'en', baseUrl: BASE };
+
+    it('emits one prefixed record per enabled locale', () => {
+      const out = expandLocales([entry('/shoes')], opts);
+      expect(out.map((r) => r.loc)).toEqual([
+        'https://shop.com/shoes',
+        'https://shop.com/de/shoes',
+        'https://shop.com/fr/shoes'
+      ]);
+    });
+
+    it('attaches the full self-referential alternate set + x-default to every record', () => {
+      const out = expandLocales([entry('/shoes')], opts);
+      const expected = [
+        { hreflang: 'en', href: 'https://shop.com/shoes' },
+        { hreflang: 'de', href: 'https://shop.com/de/shoes' },
+        { hreflang: 'fr', href: 'https://shop.com/fr/shoes' },
+        { hreflang: 'x-default', href: 'https://shop.com/shoes' }
+      ];
+      for (const record of out) {
+        expect(record.alternates).toEqual(expected);
+      }
+    });
+
+    it('localizes the homepage to /<locale>, never /<locale>/', () => {
+      const out = expandLocales([entry('/')], opts);
+      expect(out.map((r) => r.loc)).toEqual([
+        'https://shop.com/',
+        'https://shop.com/de',
+        'https://shop.com/fr'
+      ]);
+      expect(out[0].alternates).toContainEqual({
+        hreflang: 'x-default',
+        href: 'https://shop.com/'
+      });
+      expect(out[1].alternates).toContainEqual({
+        hreflang: 'de',
+        href: 'https://shop.com/de'
+      });
+    });
+
+    it('drops alternates when hreflang is false but keeps per-locale records', () => {
+      const out = expandLocales([entry('/shoes')], { ...opts, hreflang: false });
+      expect(out).toHaveLength(3);
+      for (const record of out) {
+        expect(record.alternates).toBeUndefined();
+      }
+      expect(out.map((r) => r.loc)).toEqual([
+        'https://shop.com/shoes',
+        'https://shop.com/de/shoes',
+        'https://shop.com/fr/shoes'
+      ]);
+    });
+
+    it('normalizes hreflang codes (underscore→hyphen) but keeps the raw URL segment', () => {
+      const out = expandLocales([entry('/shoes')], {
+        locales: ['en', 'pt_br'],
+        defaultLocale: 'en',
+        baseUrl: BASE
+      });
+      expect(out[1].loc).toBe('https://shop.com/pt_br/shoes');
+      expect(out[1].alternates).toContainEqual({
+        hreflang: 'pt-br',
+        href: 'https://shop.com/pt_br/shoes'
+      });
+    });
+
+    it('passes already-absolute paths through unchanged (no prefix)', () => {
+      const out = expandLocales([entry('https://cdn.example.com/x')], opts);
+      for (const record of out) {
+        expect(record.loc).toBe('https://cdn.example.com/x');
+      }
+    });
+
+    it('preserves changefreq and priority on every locale record', () => {
+      const out = expandLocales(
+        [entry('/shoes', { changefreq: 'daily', priority: 0.7 })],
+        opts
+      );
+      for (const record of out) {
+        expect(record.changefreq).toBe('daily');
+        expect(record.priority).toBe(0.7);
+      }
+    });
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/fingerprint.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/fingerprint.test.ts
@@ -1,0 +1,126 @@
+import { buildFingerprint, hasChanged } from '../../fingerprint.js';
+import { CollectorStat } from '../../types.js';
+
+const stat = (count: number, maxUpdatedAt: string | null): CollectorStat => ({
+  count,
+  maxUpdatedAt
+});
+
+describe('buildFingerprint', () => {
+  it('is deterministic regardless of entry and locale order', () => {
+    const a = buildFingerprint(
+      [
+        { name: 'products', stat: stat(5, '2026-01-01T00:00:00.000Z') },
+        { name: 'categories', stat: stat(3, '2026-01-02T00:00:00.000Z') }
+      ],
+      ['en', 'de'],
+      'en'
+    );
+    const b = buildFingerprint(
+      [
+        { name: 'categories', stat: stat(3, '2026-01-02T00:00:00.000Z') },
+        { name: 'products', stat: stat(5, '2026-01-01T00:00:00.000Z') }
+      ],
+      ['de', 'en'],
+      'en'
+    );
+    expect(a).toBe(b);
+  });
+
+  it('treats a null maxUpdatedAt as empty', () => {
+    expect(
+      buildFingerprint([{ name: 'products', stat: stat(0, null) }], ['en'], 'en')
+    ).toContain('products:0:');
+  });
+});
+
+describe('hasChanged', () => {
+  const base = buildFingerprint(
+    [{ name: 'products', stat: stat(5, '2026-01-01T00:00:00.000Z') }],
+    ['en'],
+    'en'
+  );
+
+  it('is true when there is no prior fingerprint', () => {
+    expect(hasChanged(null, base)).toBe(true);
+  });
+
+  it('is false on identity', () => {
+    const same = buildFingerprint(
+      [{ name: 'products', stat: stat(5, '2026-01-01T00:00:00.000Z') }],
+      ['en'],
+      'en'
+    );
+    expect(hasChanged(base, same)).toBe(false);
+  });
+
+  it('is true when a count changes', () => {
+    const next = buildFingerprint(
+      [{ name: 'products', stat: stat(6, '2026-01-01T00:00:00.000Z') }],
+      ['en'],
+      'en'
+    );
+    expect(hasChanged(base, next)).toBe(true);
+  });
+
+  it('is true when maxUpdatedAt advances', () => {
+    const next = buildFingerprint(
+      [{ name: 'products', stat: stat(5, '2026-02-01T00:00:00.000Z') }],
+      ['en'],
+      'en'
+    );
+    expect(hasChanged(base, next)).toBe(true);
+  });
+
+  it('is true when the paths hash changes but count/updated_at do not (URL moved)', () => {
+    // The exact "assign a category" bug: same count + same updated_at, different URL.
+    const before = buildFingerprint(
+      [{ name: 'products', stat: { count: 1, maxUpdatedAt: 'x', pathsHash: 'root' } }],
+      ['en'],
+      'en'
+    );
+    const after = buildFingerprint(
+      [{ name: 'products', stat: { count: 1, maxUpdatedAt: 'x', pathsHash: 'nested' } }],
+      ['en'],
+      'en'
+    );
+    expect(hasChanged(before, after)).toBe(true);
+  });
+
+  it('is false when the paths hash is identical', () => {
+    const a = buildFingerprint(
+      [{ name: 'products', stat: { count: 1, maxUpdatedAt: 'x', pathsHash: 'same' } }],
+      ['en'],
+      'en'
+    );
+    const b = buildFingerprint(
+      [{ name: 'products', stat: { count: 1, maxUpdatedAt: 'x', pathsHash: 'same' } }],
+      ['en'],
+      'en'
+    );
+    expect(hasChanged(a, b)).toBe(false);
+  });
+
+  it('is true when a locale is added', () => {
+    const next = buildFingerprint(
+      [{ name: 'products', stat: stat(5, '2026-01-01T00:00:00.000Z') }],
+      ['en', 'de'],
+      'en'
+    );
+    expect(hasChanged(base, next)).toBe(true);
+  });
+
+  it('is true when the default locale changes (same enabled set)', () => {
+    const enDefault = buildFingerprint(
+      [{ name: 'products', stat: stat(5, 'x') }],
+      ['en', 'de'],
+      'en'
+    );
+    const deDefault = buildFingerprint(
+      [{ name: 'products', stat: stat(5, 'x') }],
+      ['en', 'de'],
+      'de'
+    );
+    expect(hasChanged(enDefault, deDefault)).toBe(true);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/generateSitemap.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/generateSitemap.test.ts
@@ -1,0 +1,175 @@
+import { getSitemapConfig } from '../../config.js';
+import { generateSitemap } from '../../generateSitemap.js';
+import { SitemapMeta, SitemapStorage } from '../../storage.js';
+import { SitemapCollector, SitemapEntry } from '../../types.js';
+
+/** An in-memory SitemapStorage for wiring/skip tests, with the written files exposed. */
+function createMemoryStorage(): {
+  storage: SitemapStorage;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  const state: { meta: SitemapMeta | null } = { meta: null };
+  const storage: SitemapStorage = {
+    async writeFiles(toWrite) {
+      for (const file of toWrite) files.set(file.name, file.content);
+    },
+    async readFile(name) {
+      return files.has(name) ? Buffer.from(files.get(name) as string) : null;
+    },
+    async fileExists(name) {
+      return files.has(name);
+    },
+    async readMeta() {
+      return state.meta;
+    },
+    async writeMeta(meta) {
+      state.meta = meta;
+    },
+    async pruneOrphans(keep) {
+      for (const name of [...files.keys()]) {
+        if (/^sitemap(-[a-z0-9-]+)?\.xml$/.test(name) && !keep.includes(name)) {
+          files.delete(name);
+        }
+      }
+    }
+  };
+  return { storage, files };
+}
+
+const collector = (
+  name: string,
+  entries: SitemapEntry[],
+  hooks: { onCollect?: () => void; count?: number; maxUpdatedAt?: string | null } = {}
+): SitemapCollector => ({
+  name,
+  async collect() {
+    hooks.onCollect?.();
+    return entries;
+  },
+  async getFingerprint() {
+    return {
+      count: hooks.count ?? entries.length,
+      maxUpdatedAt: hooks.maxUpdatedAt ?? null
+    };
+  }
+});
+
+const BASE = {
+  config: getSitemapConfig(),
+  baseUrl: 'https://shop.com',
+  locales: ['en', 'de'],
+  defaultLocale: 'en',
+  clock: () => 1_000_000
+};
+
+describe('generateSitemap — wiring', () => {
+  it('produces an index + per-collector children with multi-locale hreflang', async () => {
+    const { storage, files } = createMemoryStorage();
+    const collectors = [
+      collector('products', [
+        {
+          path: '/a',
+          lastmod: '2026-01-01T00:00:00.000Z',
+          changefreq: 'daily' as const,
+          priority: 0.7
+        }
+      ]),
+      collector('categories', [{ path: '/b' }]),
+      collector('empty', []) // 0 URLs ⇒ no child, no index entry
+    ];
+
+    const result = await generateSitemap({
+      ...BASE,
+      force: true,
+      collectors,
+      storage
+    });
+
+    expect(result.generated).toBe(true);
+    expect(result.files).toEqual([
+      'sitemap.xml',
+      'sitemap-products.xml',
+      'sitemap-categories.xml'
+    ]);
+    expect(result.urlCount).toBe(4); // 2 entries × 2 locales
+    expect(files.has('sitemap-empty.xml')).toBe(false);
+
+    const index = files.get('sitemap.xml') as string;
+    expect(index).toContain('<sitemapindex');
+    expect(index).toContain('https://shop.com/sitemap-products.xml');
+    expect(index).toContain('https://shop.com/sitemap-categories.xml');
+
+    const products = files.get('sitemap-products.xml') as string;
+    expect(products).toContain('xmlns:xhtml');
+    expect(products).toContain('<loc>https://shop.com/a</loc>');
+    expect(products).toContain('<loc>https://shop.com/de/a</loc>');
+    expect(products).toContain('hreflang="x-default"');
+  });
+});
+
+describe('generateSitemap — single-flight', () => {
+  it('coalesces concurrent calls into one generation', async () => {
+    let collectCount = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slow: SitemapCollector = {
+      name: 'slow',
+      async collect() {
+        collectCount += 1;
+        await gate;
+        return [{ path: '/a' }];
+      },
+      async getFingerprint() {
+        return { count: 1, maxUpdatedAt: null };
+      }
+    };
+    const { storage } = createMemoryStorage();
+    const opts = { ...BASE, force: true, collectors: [slow], storage };
+
+    const p1 = generateSitemap(opts);
+    const p2 = generateSitemap(opts);
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(collectCount).toBe(1);
+    expect(r1).toBe(r2); // same coalesced result
+  });
+});
+
+describe('generateSitemap — fingerprint skip', () => {
+  it('skips when unchanged and fresh, regenerates when stale', async () => {
+    const { storage } = createMemoryStorage();
+    let collectCount = 0;
+    const collectors = [
+      collector(
+        'products',
+        [{ path: '/a', lastmod: '2026-01-01T00:00:00.000Z' }],
+        { onCollect: () => (collectCount += 1), count: 1, maxUpdatedAt: '2026-01-01T00:00:00.000Z' }
+      )
+    ];
+    const T = 1_000_000;
+
+    // First run generates.
+    const r1 = await generateSitemap({ ...BASE, collectors, storage, force: true, clock: () => T });
+    expect(r1.generated).toBe(true);
+    expect(collectCount).toBe(1);
+
+    // Same fingerprint, within max-age, files present ⇒ skip (no re-collect).
+    const r2 = await generateSitemap({ ...BASE, collectors, storage, clock: () => T + 1000 });
+    expect(r2.generated).toBe(false);
+    expect(collectCount).toBe(1);
+
+    // Past max-age ⇒ regenerate even though the fingerprint is unchanged.
+    const r3 = await generateSitemap({
+      ...BASE,
+      collectors,
+      storage,
+      clock: () => T + 25 * 60 * 60 * 1000
+    });
+    expect(r3.generated).toBe(true);
+    expect(collectCount).toBe(2);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/mappers.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/mappers.test.ts
@@ -1,0 +1,69 @@
+import {
+  mapEntityRows,
+  mapStaticPaths
+} from '../../collectors/mappers.js';
+
+describe('mapEntityRows', () => {
+  it('maps request_path to canonical path and updated_at to ISO lastmod', () => {
+    const out = mapEntityRows(
+      [{ request_path: '/women/shoes/awesome', updated_at: '2026-01-01T10:00:00.000Z' }],
+      { changefreq: 'daily', priority: 0.7 }
+    );
+    expect(out).toEqual([
+      {
+        path: '/women/shoes/awesome',
+        lastmod: '2026-01-01T10:00:00.000Z',
+        changefreq: 'daily',
+        priority: 0.7
+      }
+    ]);
+  });
+
+  it('accepts a Date updated_at', () => {
+    const out = mapEntityRows([
+      { request_path: '/x', updated_at: new Date('2026-03-04T05:06:07.000Z') }
+    ]);
+    expect(out[0].lastmod).toBe('2026-03-04T05:06:07.000Z');
+  });
+
+  it('omits lastmod for null / invalid updated_at', () => {
+    expect(
+      mapEntityRows([{ request_path: '/x', updated_at: null }])[0].lastmod
+    ).toBeUndefined();
+    expect(
+      mapEntityRows([{ request_path: '/y', updated_at: 'not-a-date' }])[0].lastmod
+    ).toBeUndefined();
+  });
+
+  it('skips rows without a request_path', () => {
+    const out = mapEntityRows([
+      { request_path: '', updated_at: null },
+      { request_path: '/ok', updated_at: null }
+    ]);
+    expect(out).toEqual([{ path: '/ok' }]);
+  });
+
+  it('returns [] for no rows', () => {
+    expect(mapEntityRows([])).toEqual([]);
+  });
+
+  it('does not inject changefreq / priority when not configured', () => {
+    expect(mapEntityRows([{ request_path: '/x', updated_at: null }])[0]).toEqual({
+      path: '/x'
+    });
+  });
+});
+
+describe('mapStaticPaths', () => {
+  it('maps configured static paths', () => {
+    expect(
+      mapStaticPaths([{ path: '/', priority: 1, changefreq: 'daily' }])
+    ).toEqual([{ path: '/', priority: 1, changefreq: 'daily' }]);
+  });
+
+  it('skips non-root-relative paths', () => {
+    expect(
+      mapStaticPaths([{ path: 'https://x.com' }, { path: 'foo' }, { path: '/ok' }])
+    ).toEqual([{ path: '/ok' }]);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/registry.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/registry.test.ts
@@ -1,0 +1,26 @@
+import {
+  getSitemapCollectors,
+  registerSitemapCollector
+} from '../../registry.js';
+import { SitemapCollector } from '../../types.js';
+
+const stub = (name: string): SitemapCollector => ({
+  name,
+  async collect() {
+    return [];
+  }
+});
+
+describe('sitemap collector registry', () => {
+  // The registry caches a value on first read and only clears it at the bootstrap lock, so all
+  // registration must precede the first `getSitemapCollectors()` — which is exactly the real
+  // order (register in bootstrap, read at request/cron time). We register first, then read once.
+  it('returns the collectors registered before the first read', () => {
+    registerSitemapCollector(stub('alpha'));
+    registerSitemapCollector(stub('beta'));
+    const names = getSitemapCollectors().map((collector) => collector.name);
+    expect(names).toContain('alpha');
+    expect(names).toContain('beta');
+    expect(names).toHaveLength(2);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderIndex.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderIndex.test.ts
@@ -1,0 +1,37 @@
+import { renderIndex } from '../../render/renderIndex.js';
+
+describe('renderIndex', () => {
+  it('renders a child <loc> as baseUrl + /sitemap-<name>.xml', () => {
+    const xml = renderIndex(
+      [{ name: 'products', lastmod: '2026-01-01T00:00:00.000Z' }],
+      'https://shop.com'
+    );
+    expect(xml).toContain(
+      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    expect(xml).toContain('<loc>https://shop.com/sitemap-products.xml</loc>');
+    expect(xml).toContain('<lastmod>2026-01-01T00:00:00.000Z</lastmod>');
+  });
+
+  it('renders multiple children', () => {
+    const xml = renderIndex(
+      [{ name: 'products' }, { name: 'categories' }],
+      'https://shop.com'
+    );
+    expect(xml).toContain('https://shop.com/sitemap-products.xml');
+    expect(xml).toContain('https://shop.com/sitemap-categories.xml');
+    expect((xml.match(/<sitemap>/g) || []).length).toBe(2);
+  });
+
+  it('omits <lastmod> when absent', () => {
+    const xml = renderIndex([{ name: 'static' }], 'https://shop.com');
+    expect(xml).not.toContain('<lastmod>');
+  });
+
+  it('renders an empty index for no children', () => {
+    const xml = renderIndex([], 'https://shop.com');
+    expect(xml).toContain('<sitemapindex');
+    expect(xml).toContain('</sitemapindex>');
+    expect(xml).not.toContain('<sitemap>');
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderRobotsTxt.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderRobotsTxt.test.ts
@@ -1,0 +1,32 @@
+import { renderRobotsTxt } from '../../render/renderRobotsTxt.js';
+
+describe('renderRobotsTxt', () => {
+  it('renders the default body with an absolute Sitemap line', () => {
+    const txt = renderRobotsTxt({
+      sitemapUrl: 'https://shop.com/sitemap.xml',
+      disallow: ['/admin/', '/checkout']
+    });
+    expect(txt).toContain('User-agent: *');
+    expect(txt).toContain('Disallow: /admin/');
+    expect(txt).toContain('Disallow: /checkout');
+    expect(txt).toContain('Sitemap: https://shop.com/sitemap.xml');
+  });
+
+  it('emits a bare "Disallow:" (allow all) when the disallow list is empty', () => {
+    const txt = renderRobotsTxt({
+      sitemapUrl: 'https://shop.com/sitemap.xml',
+      disallow: []
+    });
+    expect(txt.split('\n')).toContain('Disallow:');
+  });
+
+  it('omits the Sitemap line when includeSitemap is false', () => {
+    const txt = renderRobotsTxt({
+      sitemapUrl: 'https://shop.com/sitemap.xml',
+      disallow: ['/admin/'],
+      includeSitemap: false
+    });
+    expect(txt).not.toContain('Sitemap:');
+    expect(txt).toContain('Disallow: /admin/');
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderUrlset.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/renderUrlset.test.ts
@@ -1,0 +1,74 @@
+import { renderUrlset } from '../../render/renderUrlset.js';
+import { SitemapUrlRecord } from '../../types.js';
+
+describe('renderUrlset', () => {
+  it('renders <loc> from record.loc and a valid XML prolog', () => {
+    const xml = renderUrlset([{ loc: 'https://shop.com/shoes' }]);
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain('<loc>https://shop.com/shoes</loc>');
+  });
+
+  it('omits optional tags when absent', () => {
+    const xml = renderUrlset([{ loc: 'https://shop.com/a' }]);
+    expect(xml).not.toContain('<lastmod>');
+    expect(xml).not.toContain('<changefreq>');
+    expect(xml).not.toContain('<priority>');
+  });
+
+  it('renders optional tags when present', () => {
+    const record: SitemapUrlRecord = {
+      loc: 'https://shop.com/a',
+      lastmod: '2026-01-01T00:00:00.000Z',
+      changefreq: 'daily',
+      priority: 0.7
+    };
+    const xml = renderUrlset([record]);
+    expect(xml).toContain('<lastmod>2026-01-01T00:00:00.000Z</lastmod>');
+    expect(xml).toContain('<changefreq>daily</changefreq>');
+    expect(xml).toContain('<priority>0.7</priority>');
+  });
+
+  it('declares xmlns:xhtml and renders <xhtml:link> only when a record has alternates', () => {
+    const without = renderUrlset([{ loc: 'https://shop.com/a' }]);
+    expect(without).not.toContain('xmlns:xhtml');
+    expect(without).not.toContain('<xhtml:link');
+
+    const withAlt = renderUrlset([
+      {
+        loc: 'https://shop.com/a',
+        alternates: [{ hreflang: 'en', href: 'https://shop.com/a' }]
+      }
+    ]);
+    expect(withAlt).toContain('xmlns:xhtml="http://www.w3.org/1999/xhtml"');
+    expect(withAlt).toContain(
+      '<xhtml:link rel="alternate" hreflang="en" href="https://shop.com/a"/>'
+    );
+  });
+
+  it('entity-escapes the loc', () => {
+    const xml = renderUrlset([{ loc: 'https://shop.com/a?x=1&y=2' }]);
+    expect(xml).toContain('<loc>https://shop.com/a?x=1&amp;y=2</loc>');
+  });
+
+  it('renders an empty namespace-free urlset for no records', () => {
+    const xml = renderUrlset([]);
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    expect(xml).toContain('</urlset>');
+    expect(xml).not.toContain('<url>');
+    expect(xml).not.toContain('xmlns:xhtml');
+  });
+
+  it('clamps priority to one decimal within [0,1]', () => {
+    expect(renderUrlset([{ loc: 'x', priority: 1 }])).toContain(
+      '<priority>1.0</priority>'
+    );
+    expect(renderUrlset([{ loc: 'x', priority: 5 }])).toContain(
+      '<priority>1.0</priority>'
+    );
+    expect(renderUrlset([{ loc: 'x', priority: -1 }])).toContain(
+      '<priority>0.0</priority>'
+    );
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/tests/unit/storage.test.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/tests/unit/storage.test.ts
@@ -1,0 +1,84 @@
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  SitemapMeta,
+  createLocalSitemapStorage
+} from '../../storage.js';
+
+describe('createLocalSitemapStorage', () => {
+  let publicDir: string;
+  let cacheDir: string;
+  let storage: ReturnType<typeof createLocalSitemapStorage>;
+
+  beforeEach(async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'sitemap-store-'));
+    publicDir = path.join(root, 'public');
+    cacheDir = path.join(root, 'cache');
+    await fsp.mkdir(publicDir, { recursive: true });
+    storage = createLocalSitemapStorage({ publicDir, cacheDir });
+  });
+
+  it('writes and reads files (round-trip)', async () => {
+    await storage.writeFiles([
+      { name: 'sitemap.xml', content: '<index/>' },
+      { name: 'sitemap-products.xml', content: '<urlset/>' }
+    ]);
+    expect((await storage.readFile('sitemap.xml'))?.toString()).toBe('<index/>');
+    expect((await storage.readFile('sitemap-products.xml'))?.toString()).toBe(
+      '<urlset/>'
+    );
+    // Written to the flat public root (not a /sitemap/ subfolder).
+    expect(await fsp.readdir(publicDir)).toEqual(
+      expect.arrayContaining(['sitemap.xml', 'sitemap-products.xml'])
+    );
+  });
+
+  it('reports existence and returns null for missing files', async () => {
+    await storage.writeFiles([{ name: 'sitemap.xml', content: '<x/>' }]);
+    expect(await storage.fileExists('sitemap.xml')).toBe(true);
+    expect(await storage.fileExists('sitemap-nope.xml')).toBe(false);
+    expect(await storage.readFile('sitemap-nope.xml')).toBeNull();
+  });
+
+  it('round-trips meta and returns null when absent', async () => {
+    expect(await storage.readMeta()).toBeNull();
+    const meta: SitemapMeta = {
+      fingerprint: 'fp',
+      generatedAt: '2026-07-05T00:00:00.000Z',
+      files: ['sitemap.xml'],
+      urlCount: 3
+    };
+    await storage.writeMeta(meta);
+    expect(await storage.readMeta()).toEqual(meta);
+  });
+
+  it('prunes only stale sitemap files, never other public files', async () => {
+    await storage.writeFiles([
+      { name: 'sitemap.xml', content: '<x/>' },
+      { name: 'sitemap-products.xml', content: '<x/>' },
+      { name: 'sitemap-old.xml', content: '<x/>' }
+    ]);
+    await fsp.writeFile(path.join(publicDir, 'robots.txt'), 'User-agent: *');
+    await fsp.writeFile(path.join(publicDir, 'favicon.ico'), 'icon');
+
+    await storage.pruneOrphans(['sitemap.xml', 'sitemap-products.xml']);
+
+    const remaining = await fsp.readdir(publicDir);
+    expect(remaining).toEqual(
+      expect.arrayContaining([
+        'sitemap.xml',
+        'sitemap-products.xml',
+        'robots.txt',
+        'favicon.ico'
+      ])
+    );
+    expect(remaining).not.toContain('sitemap-old.xml');
+  });
+
+  it('leaves no .tmp files behind after an atomic write', async () => {
+    await storage.writeFiles([{ name: 'sitemap.xml', content: '<x/>' }]);
+    const remaining = await fsp.readdir(publicDir);
+    expect(remaining.some((f) => f.includes('.tmp'))).toBe(false);
+  });
+});

--- a/packages/evershop/src/modules/base/services/sitemap/types.ts
+++ b/packages/evershop/src/modules/base/services/sitemap/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Sitemap module — shared types.
+ *
+ * The generation pipeline is: collectors emit canonical `SitemapEntry` paths →
+ * `expandLocales` turns each into one absolute, localized `SitemapUrlRecord` per
+ * enabled locale (with hreflang alternates) → the renderer serializes records into
+ * XML. See wiki/sitemap-design.md §3.
+ */
+
+/** sitemaps.org `<changefreq>` vocabulary. Google ignores this tag, but other engines use it. */
+export type SitemapChangeFreq =
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
+
+/**
+ * A URL as produced by a collector: a CANONICAL, root-relative path (never absolute,
+ * never locale-prefixed) — exactly a `url_rewrite.request_path` (e.g. `/women/shoes/awesome-shoes`).
+ * The base URL and locale prefixing are applied later, by `expandLocales`.
+ */
+export interface SitemapEntry {
+  path: string;
+  /** ISO-8601, from the entity's `updated_at`. Omitted when unknown. */
+  lastmod?: string;
+  changefreq?: SitemapChangeFreq;
+  /** 0.0 – 1.0. Google ignores it. */
+  priority?: number;
+}
+
+/** One `<xhtml:link rel="alternate">` in a localized `<url>`. */
+export interface SitemapAlternate {
+  hreflang: string;
+  href: string;
+}
+
+/**
+ * A URL ready for rendering: absolute `loc`, and — on multi-locale stores — the full
+ * self-referential hreflang alternate set (including `x-default`). Produced by `expandLocales`.
+ */
+export interface SitemapUrlRecord {
+  loc: string;
+  lastmod?: string;
+  changefreq?: SitemapChangeFreq;
+  priority?: number;
+  alternates?: SitemapAlternate[];
+}
+
+/**
+ * The cheap change signal a collector exposes for the generation fingerprint:
+ *  - `count` / `maxUpdatedAt` — detect adds/removes and content edits (the latter drives `<lastmod>`).
+ *  - `pathsHash` — a hash of the included URLs themselves, so a URL that changes WITHOUT bumping the
+ *    entity's `updated_at` (a category assign/move/reparent, or the async `url_rewrite` rebuild
+ *    racing generation) still flips the fingerprint. Omit it to opt out (forces the count/updated_at
+ *    signal only). `null` when the collector is empty.
+ */
+export interface CollectorStat {
+  count: number;
+  maxUpdatedAt: string | null;
+  pathsHash?: string | null;
+}
+
+/**
+ * A source of sitemap URLs. Core ships collectors for products, categories, CMS pages,
+ * landing pages and static routes; extensions register their own via `registerSitemapCollector`.
+ * `name` is also the child-file basename (`sitemap-<name>.xml`), so it must be a URL-safe slug.
+ */
+export interface SitemapCollector {
+  name: string;
+  collect(): Promise<SitemapEntry[]>;
+  /**
+   * Optional cheap fingerprint. Omit to force a full regeneration on every run (safe default
+   * for third-party collectors that can't cheaply summarise their set).
+   */
+  getFingerprint?(): Promise<CollectorStat>;
+}

--- a/packages/evershop/src/modules/blog/bootstrap.ts
+++ b/packages/evershop/src/modules/blog/bootstrap.ts
@@ -9,12 +9,49 @@ import {
   registerLinkLoader
 } from '../../lib/widget/linkResolver.js';
 import { registerWidget } from '../../lib/widget/widgetManager.js';
+import {
+  createEntityCollector,
+  registerSitemapCollector
+} from '../base/services/sitemap/index.js';
 import { registerDefaultBlogCategoryFilters } from './services/registerDefaultBlogCategoryFilters.js';
 import { registerDefaultBlogCommentFilters } from './services/registerDefaultBlogCommentFilters.js';
 import { registerDefaultBlogPostFilters } from './services/registerDefaultBlogPostFilters.js';
 import { registerDefaultBlogTagFilters } from './services/registerDefaultBlogTagFilters.js';
 
 export default (): void => {
+  // Sitemap: register blog URLs (posts, categories, tags — all url_rewrite-backed) so they
+  // appear in /sitemap.xml. Each becomes a sitemap-blog-<x>.xml child.
+  registerSitemapCollector(
+    createEntityCollector({
+      name: 'blog-posts',
+      table: 'blog_post',
+      entityType: 'blog_post',
+      where: 'e.status = 1', // published
+      changefreq: 'weekly',
+      priority: 0.5
+    })
+  );
+  registerSitemapCollector(
+    createEntityCollector({
+      name: 'blog-categories',
+      table: 'blog_category',
+      entityType: 'blog_category',
+      where: 'e.status = 1',
+      changefreq: 'weekly',
+      priority: 0.4
+    })
+  );
+  registerSitemapCollector(
+    createEntityCollector({
+      name: 'blog-tags',
+      table: 'blog_tag',
+      entityType: 'blog_tag',
+      updatedAtColumn: 'created_at', // blog_tag has no updated_at
+      changefreq: 'monthly',
+      priority: 0.3
+    })
+  );
+
   // Link loaders: resolve blog URNs → current URLs at request time (prefer the
   // pretty url_rewrite path, fall back to the internal route).
   const blogLinkLoader = (entityType: string, routeId: string) =>


### PR DESCRIPTION
Generate a search-engine sitemap (index + per-type children) at /sitemap.xml plus a dynamic robots.txt. Housed in the base module.

- Collectors for products, categories, CMS pages, landing pages, static routes, and blog (posts/categories/tags); pluggable via registerSitemapCollector.
- Multi-language hreflang alternates; 50k-per-file chunking.
- Cron regeneration with a change-fingerprint skip (count + max(updated_at) + request-path hash) and a max-age backstop.
- Served warm by publicStatic; a notFound-gated frontStore/all middleware generates on first miss.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
