### PR TITLE
feat: make page-builder drops and moves layout-component-aware

### DIFF
--- a/packages/evershop/src/components/common/Area.tsx
+++ b/packages/evershop/src/components/common/Area.tsx
@@ -1,5 +1,5 @@
 import { useAppState } from '@components/common/context/app.js';
-import { AreaStartDropZone } from '@components/common/page-builder/AreaStartDropZone.js';
+import { AreaDropZone } from '@components/common/page-builder/AreaDropZone.js';
 import { useIsInPageBuilderIframe } from '@components/common/page-builder/pageBuilderMode.js';
 import { WidgetChrome } from '@components/common/page-builder/WidgetChrome.js';
 import { generateComponentKey } from '@evershop/evershop/lib/util/keyGenerator';
@@ -409,7 +409,6 @@ function Area(props: AreaProps) {
           uuid={w._widgetMeta.uuid}
           type={w._widgetMeta.type}
           area={id}
-          editableInPageBuilder={editableInPageBuilder === true}
           sortOrder={Number(w.sortOrder ?? 0)}
           settings={w._widgetMeta.settings}
         >
@@ -434,42 +433,62 @@ function Area(props: AreaProps) {
       );
     }
 
-    if (!debug || rendered === null || process.env.NODE_ENV !== 'development') {
-      return rendered;
-    }
-
-    return (
-      <div
-        key={index}
-        className="evershop-debug-child"
-        style={{
-          position: 'relative',
-          outline: `1px solid ${color}40`,
-          outlineOffset: '1px'
-        }}
-      >
-        <span
+    if (
+      debug &&
+      rendered !== null &&
+      process.env.NODE_ENV === 'development'
+    ) {
+      rendered = (
+        <div
+          key={index}
+          className="evershop-debug-child"
           style={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            zIndex: 9999,
-            background: `${color}cc`,
-            color: '#fff',
-            fontSize: '9px',
-            fontFamily: 'monospace',
-            padding: '1px 5px',
-            borderRadius: '0 0 0 4px',
-            lineHeight: '16px',
-            whiteSpace: 'nowrap',
-            pointerEvents: 'none'
+            position: 'relative',
+            outline: `1px solid ${color}40`,
+            outlineOffset: '1px'
           }}
         >
-          order: {w.sortOrder ?? 0}
-        </span>
-        {rendered}
-      </div>
-    );
+          <span
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              zIndex: 9999,
+              background: `${color}cc`,
+              color: '#fff',
+              fontSize: '9px',
+              fontFamily: 'monospace',
+              padding: '1px 5px',
+              borderRadius: '0 0 0 4px',
+              lineHeight: '16px',
+              whiteSpace: 'nowrap',
+              pointerEvents: 'none'
+            }}
+          >
+            order: {w.sortOrder ?? 0}
+          </span>
+          {rendered}
+        </div>
+      );
+    }
+
+    // Drop seam after every renderable — widget instances AND layout
+    // components — so a new widget can land between or below anything the
+    // area renders, not just adjacent to existing widgets. The zone walks
+    // its tagged siblings at drop time (`computeDropSortOrder`), so no
+    // sort_order threading is needed here beyond the widget uuid used as
+    // an e2e/debug hook. Emitted only inside the page-builder iframe for
+    // areas that opted into editing; production DOM is unchanged.
+    if (rendered !== null && inPageBuilder && editableInPageBuilder) {
+      rendered = (
+        <React.Fragment key={index}>
+          {rendered}
+          <AreaDropZone areaId={id} afterUid={w._widgetMeta?.uuid} />
+        </React.Fragment>
+      );
+    }
+
+    return rendered;
   });
 
   // Drop zone above everything in the area, only emitted for areas the page
@@ -478,7 +497,7 @@ function Area(props: AreaProps) {
   // own `sortOrder` at drop time by walking sibling DOM elements that carry
   // `data-evershop-pb-sort-order` — no prop threading needed.
   const startDropZone = editableInPageBuilder ? (
-    <AreaStartDropZone areaId={id} />
+    <AreaDropZone areaId={id} variant="start" />
   ) : null;
 
   if (process.env.NODE_ENV === 'development' && debug) {

--- a/packages/evershop/src/components/common/page-builder/AreaDropZone.tsx
+++ b/packages/evershop/src/components/common/page-builder/AreaDropZone.tsx
@@ -3,30 +3,49 @@ import { computeDropSortOrder } from './dropSortOrder.js';
 import { isInPageBuilderIframe, postToParent } from './pageBuilderMode.js';
 
 /**
- * Drop zone rendered as the first child of every Area marked
- * `editableInPageBuilder`. Gives the page-builder a way to drop above
- * everything in the area — including layout components like ShoppingCart
- * that aren't wrapped in `WidgetChrome` and therefore don't carry their own
- * after-widget drop zones.
+ * The page builder's drop seam. `Area.tsx` owns every instance: one as the
+ * first child of each Area marked `editableInPageBuilder`
+ * (`variant="start"`), and one after every renderable in such an Area —
+ * widget instances and layout components alike. That makes each gap in the
+ * rendered order a drop target: above everything, between any two
+ * renderables (widget-widget, widget-layout, layout-layout), and below the
+ * last one.
  *
- * Reuses the `data-evershop-pb-dropzone` attribute and the existing CSS
- * rules in `WidgetChrome.tsx` for visibility (only shown while a drag is
- * in flight — `body[data-evershop-pb-drag="true"]`).
+ * Visibility and styling come from the `[data-evershop-pb-dropzone]` rules
+ * in the chrome stylesheet (`ensureChromeStyleInjected` in
+ * `WidgetChrome.tsx`, guaranteed by `PageBuilderBridge` even on routes with
+ * zero widgets): zones are zero-height and inert until the admin posts
+ * `pb-drag-start`, which sets `body[data-evershop-pb-drag="true"]`.
  *
- * The drop handler walks DOM siblings to find the nearest renderable's
+ * The drop handler walks DOM siblings to find the nearest renderables'
  * `data-evershop-pb-sort-order` and computes a midpoint locally — see
  * `dropSortOrder.ts`. The admin just stores the computed value.
  *
  * SSR-safe: returns `null` outside the page-builder iframe so the production
  * storefront emits zero extra DOM.
  */
-interface AreaStartDropZoneProps {
+interface AreaDropZoneProps {
   areaId: string;
+  /**
+   * 'start' — the zone above everything in the area (Area's first child),
+   * tagged `data-evershop-pb-area-start` for e2e / debugging.
+   * 'after' (default) — the zone following one renderable.
+   */
+  variant?: 'start' | 'after';
+  /**
+   * uuid of the widget instance this zone follows, when it follows one.
+   * Surfaced as `data-evershop-pb-after` — an e2e / debugging hook only;
+   * the drop math never reads it. Zones after layout components have no
+   * uuid and omit the attribute.
+   */
+  afterUid?: string;
 }
 
-export function AreaStartDropZone({
-  areaId
-}: AreaStartDropZoneProps): React.ReactElement | null {
+export function AreaDropZone({
+  areaId,
+  variant = 'after',
+  afterUid
+}: AreaDropZoneProps): React.ReactElement | null {
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
     setIsClient(true);
@@ -80,7 +99,10 @@ export function AreaStartDropZone({
     <div
       data-evershop-pb-dropzone
       data-evershop-pb-area={areaId}
-      data-evershop-pb-area-start={areaId}
+      {...(variant === 'start'
+        ? { 'data-evershop-pb-area-start': areaId }
+        : {})}
+      {...(afterUid ? { 'data-evershop-pb-after': afterUid } : {})}
       onDragEnter={onEnter}
       onDragLeave={onLeave}
       onDragOver={onOver}

--- a/packages/evershop/src/components/common/page-builder/WidgetChrome.tsx
+++ b/packages/evershop/src/components/common/page-builder/WidgetChrome.tsx
@@ -1,6 +1,6 @@
 import { _ } from '@evershop/evershop/lib/locale/translate/_';
-import React, { useEffect, useState } from 'react';
-import { computeDropSortOrder } from './dropSortOrder.js';
+import React, { useEffect, useRef, useState } from 'react';
+import { computeMoveSortOrder } from './dropSortOrder.js';
 import { isInPageBuilderIframe, postToParent } from './pageBuilderMode.js';
 import { WidgetContextProvider } from './WidgetContext.js';
 
@@ -86,6 +86,18 @@ const CHROME_CSS = `
   }
   body[data-evershop-pb-drag="true"] [data-evershop-global="true"] [data-evershop-pb-dropzone][data-evershop-pb-area]::before {
     background: #7c3aed;
+  }
+  /* Collapse the drop zone that follows an EMPTY renderable wrapper. A
+     layout component that renders null (e.g. Breadcrumb on the homepage,
+     where there are no breadcrumbs) still gets its display:contents
+     sort-order wrapper + trailing zone from Area.tsx — without this rule
+     two bands would stack at the same visual position (the empty wrapper
+     paints nothing between them). Hiding the trailing zone loses nothing:
+     both seams sit between the same visible neighbors, so a drop on the
+     surviving one lands identically. Widget wrappers are never :empty
+     (they always contain the chrome toolbar). */
+  body[data-evershop-pb-drag="true"] [data-evershop-pb-sort-order]:empty + [data-evershop-pb-dropzone] {
+    display: none;
   }
 `;
 
@@ -256,6 +268,11 @@ function ChromeIconButton({
  * (production storefront), it renders `children` unchanged with no extra
  * markup or context — zero overhead.
  *
+ * Drop zones are NOT emitted here — `Area.tsx` owns every seam (one
+ * `AreaDropZone` after each renderable, widget or layout component, plus
+ * the area-start zone). The chrome's only drop-related duty is carrying
+ * `data-evershop-pb-sort-order` on the wrapper so zones can walk it.
+ *
  * Selection / delete are delivered to the admin via same-origin postMessage:
  *   - { type: 'widget-selected', widgetUid, widgetType, settings }
  *   - { type: 'widget-delete',   widgetUid }
@@ -273,15 +290,6 @@ interface WidgetChromeProps {
    */
   area: string;
   /**
-   * Whether the containing Area opted into page-builder editing
-   * (`<Area editableInPageBuilder>`). When false, the after-widget drop
-   * zone is suppressed so this widget's area-level container respects its
-   * non-editable contract — selection/toolbar still render (they let the
-   * user inspect/configure existing widgets) but new drops are not allowed.
-   * `AreaStartDropZone` is gated the same way on the Area side.
-   */
-  editableInPageBuilder: boolean;
-  /**
    * The placement's sort_order. Surfaced as `data-evershop-pb-sort-order`
    * on the wrapper so adjacent drop zones can walk DOM siblings and read
    * the value when computing where a new drop should land.
@@ -295,16 +303,33 @@ export function WidgetChrome({
   uuid,
   type,
   area,
-  editableInPageBuilder,
   sortOrder,
   settings,
   children
 }: WidgetChromeProps): React.ReactElement {
   // SSR-stable: first render passes through identically to production.
   const [isClient, setIsClient] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     setIsClient(true);
   }, []);
+
+  // Move up / down. Iframe owns the math (same rule as drops): compute the
+  // target sort_order from the rendered sibling order — layout components
+  // included — and send it in the message; the admin emits one UPDATE op
+  // with the value verbatim. Already first / last → null → nothing to move
+  // past, no message.
+  const postMove = (direction: 'up' | 'down') => {
+    const el = wrapperRef.current;
+    const nextSort = el ? computeMoveSortOrder(el, direction) : null;
+    if (nextSort == null) return;
+    postToParent({
+      type: direction === 'up' ? 'widget-move-up' : 'widget-move-down',
+      widgetUid: uuid,
+      area,
+      sortOrder: nextSort
+    });
+  };
 
   const inIframe = isClient && isInPageBuilderIframe();
 
@@ -338,51 +363,10 @@ export function WidgetChrome({
     );
   }
 
-  const handleDropZoneEnter = (e: React.DragEvent<HTMLDivElement>) => {
-    if (!e.dataTransfer.types.includes('application/x-evershop-widget')) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-    (e.currentTarget as HTMLDivElement).setAttribute(
-      'data-evershop-pb-active',
-      'true'
-    );
-  };
-  const handleDropZoneLeave = (e: React.DragEvent<HTMLDivElement>) => {
-    (e.currentTarget as HTMLDivElement).removeAttribute(
-      'data-evershop-pb-active'
-    );
-  };
-  const handleDropZoneOver = (e: React.DragEvent<HTMLDivElement>) => {
-    if (!e.dataTransfer.types.includes('application/x-evershop-widget')) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  };
-  const handleDropAfter = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const widgetType =
-      e.dataTransfer.getData('application/x-evershop-widget') ||
-      e.dataTransfer.getData('text/plain');
-    if (!widgetType) return;
-    const zone = e.currentTarget as HTMLDivElement;
-    zone.removeAttribute('data-evershop-pb-active');
-    document.body.removeAttribute('data-evershop-pb-drag');
-    // Iframe owns the math. Walk siblings to find prev/next sort_orders
-    // (both widgets and layout components carry the attribute) and post
-    // the pre-computed value to the admin.
-    const sortOrder = computeDropSortOrder(zone);
-    const isGlobal = !!zone.closest('[data-evershop-global="true"]');
-    postToParent({
-      type: 'pb-drop',
-      widgetType,
-      area,
-      sortOrder,
-      isGlobal
-    });
-  };
-
   return (
     <WidgetContextProvider uid={uuid} settings={settings}>
       <div
+        ref={wrapperRef}
         className="evershop-pb-widget"
         data-evershop-pb-widget-uid={uuid}
         data-evershop-pb-sort-order={sortOrder}
@@ -411,19 +395,12 @@ export function WidgetChrome({
           }}
           data-evershop-pb-toolbar
         >
-          <ChromeIconButton
-            label={_('Move up')}
-            onClick={() =>
-              postToParent({ type: 'widget-move-up', widgetUid: uuid, area })
-            }
-          >
+          <ChromeIconButton label={_('Move up')} onClick={() => postMove('up')}>
             <ArrowUpIcon />
           </ChromeIconButton>
           <ChromeIconButton
             label={_('Move down')}
-            onClick={() =>
-              postToParent({ type: 'widget-move-down', widgetUid: uuid, area })
-            }
+            onClick={() => postMove('down')}
           >
             <ArrowDownIcon />
           </ChromeIconButton>
@@ -464,25 +441,6 @@ export function WidgetChrome({
           </ChromeIconButton>
         </div>
       </div>
-      {/* Drop zone immediately AFTER this widget. Gated on
-          `editableInPageBuilder` so a widget rendered inside an Area that
-          opted out of page-builder editing doesn't expose a drop affordance.
-          (Selection / toolbar above still render — they only inspect /
-          configure / delete the existing widget, which is safe.) Visible
-          only when the body has `data-evershop-pb-drag="true"` (set by the
-          message handler above). `data-evershop-pb-area` powers the corner
-          badge CSS, `computeDropSortOrder` walks siblings at drop time. */}
-      {editableInPageBuilder && (
-        <div
-          data-evershop-pb-dropzone
-          data-evershop-pb-area={area}
-          data-evershop-pb-after={uuid}
-          onDragEnter={handleDropZoneEnter}
-          onDragLeave={handleDropZoneLeave}
-          onDragOver={handleDropZoneOver}
-          onDrop={handleDropAfter}
-        />
-      )}
     </WidgetContextProvider>
   );
 }

--- a/packages/evershop/src/components/common/page-builder/dropSortOrder.ts
+++ b/packages/evershop/src/components/common/page-builder/dropSortOrder.ts
@@ -30,6 +30,41 @@ export function computeDropSortOrder(zoneEl: Element): number {
   return 100;
 }
 
+/**
+ * Computes the sort_order that moves `widgetEl` (a tagged renderable — in
+ * practice the WidgetChrome wrapper) one visible step up or down within its
+ * Area: past its nearest *rendering* tagged sibling, layout components
+ * included — not just past the nearest widget, which is what the legacy
+ * admin-side swap could see.
+ *
+ * Landing rules mirror the drop math:
+ *   - Between two neighbors: their midpoint.
+ *   - Past the outermost neighbor (top / bottom of the area): `± 1`.
+ *   - Already first (moving up) / last (moving down): `null` — no-op,
+ *     callers should not emit an op.
+ *   - Neighbors tied on the same sort value: landing strictly between two
+ *     equal values is impossible, so land just past both (`± 1`).
+ *
+ * Unlike the drop walk above, wrappers that rendered nothing
+ * (`childNodes.length === 0` — a layout component that returned null, e.g.
+ * Breadcrumb on the homepage) are skipped: stepping "past" an invisible
+ * element would be a click that visibly does nothing.
+ */
+export function computeMoveSortOrder(
+  widgetEl: Element,
+  direction: 'up' | 'down'
+): number | null {
+  const dir =
+    direction === 'up' ? 'previousElementSibling' : 'nextElementSibling';
+  const near = walkVisible(widgetEl, dir);
+  if (near == null) return null;
+  const far = walkVisible(near.el, dir);
+  if (far == null || far.sort === near.sort) {
+    return direction === 'up' ? near.sort - 1 : near.sort + 1;
+  }
+  return (near.sort + far.sort) / 2;
+}
+
 function walk(
   start: Element,
   direction: 'previousElementSibling' | 'nextElementSibling'
@@ -42,6 +77,24 @@ function walk(
     if (raw != null && raw !== '') {
       const n = Number(raw);
       if (!Number.isNaN(n)) return n;
+    }
+    el = el[direction];
+  }
+  return null;
+}
+
+function walkVisible(
+  start: Element,
+  direction: 'previousElementSibling' | 'nextElementSibling'
+): { el: Element; sort: number } | null {
+  let el: Element | null = start[direction];
+  while (el) {
+    const raw = (el as HTMLElement).getAttribute(
+      'data-evershop-pb-sort-order'
+    );
+    if (raw != null && raw !== '' && el.childNodes.length > 0) {
+      const n = Number(raw);
+      if (!Number.isNaN(n)) return { el, sort: n };
     }
     el = el[direction];
   }

--- a/packages/evershop/src/components/common/page-builder/pageBuilderMode.ts
+++ b/packages/evershop/src/components/common/page-builder/pageBuilderMode.ts
@@ -65,7 +65,7 @@ export function postToParent(message: unknown): void {
  * output matches the production storefront byte-for-byte; the post-mount
  * effect flips it to `true` when applicable.
  *
- * Pulled into its own hook so Area, WidgetChrome, and AreaStartDropZone all
+ * Pulled into its own hook so Area, WidgetChrome, and AreaDropZone all
  * share the same detection logic without re-implementing the
  * useState/useEffect pattern in each place.
  */

--- a/packages/evershop/src/components/common/page-builder/tests/unit/moveSortOrder.test.ts
+++ b/packages/evershop/src/components/common/page-builder/tests/unit/moveSortOrder.test.ts
@@ -1,0 +1,128 @@
+import {
+  computeDropSortOrder,
+  computeMoveSortOrder
+} from '../../dropSortOrder.js';
+
+/**
+ * Pure-logic tests for the iframe-side move math (`computeMoveSortOrder`)
+ * and its deliberate asymmetry with the drop math (`computeDropSortOrder`).
+ *
+ * Jest runs in the `node` environment (no jsdom), and the walk only touches
+ * three DOM APIs — `previousElementSibling` / `nextElementSibling`,
+ * `getAttribute('data-evershop-pb-sort-order')`, and `childNodes.length` —
+ * so a hand-rolled sibling chain of stubs is enough.
+ */
+
+interface StubSpec {
+  /** data-evershop-pb-sort-order value; omit for untagged (drop zones). */
+  sort?: number;
+  /** Renders nothing — a layout component that returned null. */
+  empty?: boolean;
+}
+
+interface StubEl {
+  previousElementSibling: StubEl | null;
+  nextElementSibling: StubEl | null;
+  childNodes: unknown[];
+  getAttribute(name: string): string | null;
+}
+
+/** Build a linked sibling chain in DOM order and return it. */
+function chain(specs: StubSpec[]): StubEl[] {
+  const els: StubEl[] = specs.map((spec) => ({
+    previousElementSibling: null,
+    nextElementSibling: null,
+    childNodes: spec.empty ? [] : [{}],
+    getAttribute: (name: string) =>
+      name === 'data-evershop-pb-sort-order' && spec.sort !== undefined
+        ? String(spec.sort)
+        : null
+  }));
+  els.forEach((el, i) => {
+    el.previousElementSibling = els[i - 1] ?? null;
+    el.nextElementSibling = els[i + 1] ?? null;
+  });
+  return els;
+}
+
+const asEl = (el: StubEl) => el as unknown as Element;
+
+// A drop zone: untagged sibling the walks must skip.
+const zone: StubSpec = {};
+
+describe('computeMoveSortOrder', () => {
+  // The productView shape after a drop between the layout components:
+  // Breadcrumb@0, widget@5, ProductView@10 (zones interleaved).
+  const productViewShape = (): StubEl[] =>
+    chain([zone, { sort: 0 }, zone, { sort: 5 }, zone, { sort: 10 }, zone]);
+
+  it('moves up past a layout component to the top of the area (next − 1)', () => {
+    const els = productViewShape();
+    expect(computeMoveSortOrder(asEl(els[3]), 'up')).toBe(-1);
+  });
+
+  it('moves down past a layout component to the bottom of the area (prev + 1)', () => {
+    const els = productViewShape();
+    expect(computeMoveSortOrder(asEl(els[3]), 'down')).toBe(11);
+  });
+
+  it('lands on the midpoint when two renderables sit beyond the neighbor', () => {
+    // X@0, Y@10, W@15 — moving W up steps past Y into midpoint(0, 10).
+    const els = chain([{ sort: 0 }, zone, { sort: 10 }, zone, { sort: 15 }]);
+    expect(computeMoveSortOrder(asEl(els[4]), 'up')).toBe(5);
+  });
+
+  it('returns null when already first (up) or last (down)', () => {
+    const els = chain([{ sort: 5 }, zone, { sort: 10 }]);
+    expect(computeMoveSortOrder(asEl(els[0]), 'up')).toBeNull();
+    expect(computeMoveSortOrder(asEl(els[2]), 'down')).toBeNull();
+    // A lone renderable can't move anywhere.
+    const lone = chain([zone, { sort: 100 }, zone]);
+    expect(computeMoveSortOrder(asEl(lone[1]), 'up')).toBeNull();
+    expect(computeMoveSortOrder(asEl(lone[1]), 'down')).toBeNull();
+  });
+
+  it('skips wrappers that rendered nothing (null layout components)', () => {
+    // A@0, EMPTY@5, W@10 — up must step past A (the nearest VISIBLE
+    // renderable), not stop at the invisible wrapper.
+    const els = chain([
+      { sort: 0 },
+      zone,
+      { sort: 5, empty: true },
+      zone,
+      { sort: 10 }
+    ]);
+    expect(computeMoveSortOrder(asEl(els[4]), 'up')).toBe(-1);
+  });
+
+  it('lands past both neighbors when they are tied on one sort value', () => {
+    // A@10, B@10, W@20 — strictly between two equal values is impossible.
+    const els = chain([{ sort: 10 }, zone, { sort: 10 }, zone, { sort: 20 }]);
+    expect(computeMoveSortOrder(asEl(els[4]), 'up')).toBe(9);
+  });
+});
+
+describe('computeDropSortOrder (walk asymmetry)', () => {
+  it('does NOT skip empty wrappers — their sort still anchors the midpoint', () => {
+    // A@0, EMPTY@5, [zone], B@10 — the zone after the empty wrapper is
+    // hidden by CSS, but the empty wrapper's sort participates in walks
+    // from other zones: prev = 5, next = 10 → 7.5.
+    const els = chain([
+      { sort: 0 },
+      zone,
+      { sort: 5, empty: true },
+      zone,
+      { sort: 10 }
+    ]);
+    expect(computeDropSortOrder(asEl(els[3]))).toBe(7.5);
+  });
+
+  it('keeps the documented edge rules', () => {
+    const els = chain([zone, { sort: 0 }, zone, { sort: 10 }, zone]);
+    expect(computeDropSortOrder(asEl(els[0]))).toBe(-1); // top: next − 1
+    expect(computeDropSortOrder(asEl(els[2]))).toBe(5); // midpoint
+    expect(computeDropSortOrder(asEl(els[4]))).toBe(11); // bottom: prev + 1
+    const empty = chain([zone]);
+    expect(computeDropSortOrder(asEl(empty[0]))).toBe(100); // fresh area
+  });
+});

--- a/packages/evershop/src/modules/pageBuilder/pages/admin/pageBuilderEdit/Editor.tsx
+++ b/packages/evershop/src/modules/pageBuilder/pages/admin/pageBuilderEdit/Editor.tsx
@@ -1879,17 +1879,42 @@ export default function Editor({
     [route.id]
   );
 
-  // Move a widget up or down within its area. The toolbar sends `area` so we
-  // operate on the right placement when the widget has placements in
-  // multiple areas (e.g. a basic_menu shared via 'all/headerMiddleLeft' but
-  // also placed in 'cart/content'). Works uniformly for top-level widgets
-  // and container children (children's siblings live in the same synthetic
-  // `columnsContainer_<parent>_col_<i>` area).
+  // Layout-aware move (2026-07-06). The iframe computes the target
+  // sort_order from the full rendered sibling order — layout components
+  // included — via `computeMoveSortOrder` and sends it in the move message
+  // (the same "iframe owns the math" rule as drops). We resolve the
+  // placement from `overlayWidgetsRef` (the post-overlay widgets list from
+  // the most recent preview — source state would disagree after reorders)
+  // and emit ONE UPDATE op with the value verbatim. Collision-safe without
+  // a swap: the target is the midpoint of two RENDER-ADJACENT siblings, so
+  // no third renderable can sort between them.
+  const moveWidgetTo = useCallback(
+    async (uid: string, area: string, targetSort: number) => {
+      const me = overlayWidgetsRef.current.find(
+        (w) =>
+          w.uuid === uid && Array.isArray(w.areaId) && w.areaId.includes(area)
+      );
+      if (!me?.placementUuid) return;
+      await postOperation({
+        entity_urn: `urn:evershop:cms:widget_placement:${me.placementUuid}`,
+        old_payload: { sort_order: me.sortOrder ?? 0 },
+        new_payload: { sort_order: targetSort }
+      });
+      pushPreviewToIframe();
+    },
+    [postOperation, pushPreviewToIframe]
+  );
+
+  // Legacy move fallback — used only when the move message carries no
+  // iframe-computed `sortOrder` (an older iframe bundle). Can only step
+  // over WIDGET neighbors; layout components are invisible to it.
   //
-  // Reads from `overlayWidgetsRef` — the post-overlay widgets list captured
-  // from the most recent storefront preview. The GraphQL `widgetsForRoute`
-  // resolver reads source state only and would disagree with the iframe
-  // after several reorders.
+  // The toolbar sends `area` so we operate on the right placement when the
+  // widget has placements in multiple areas (e.g. a basic_menu shared via
+  // 'all/headerMiddleLeft' but also placed in 'cart/content'). Works
+  // uniformly for top-level widgets and container children (children's
+  // siblings live in the same synthetic `columnsContainer_<parent>_col_<i>`
+  // area).
   //
   // Algorithm: swap the two placements' `sort_order` values via two UPDATE
   // ops. This gives an unambiguous reorder — the earlier `neighbor ± 1`
@@ -2271,12 +2296,20 @@ export default function Editor({
         deleteWidget(msg.widgetUid, msg.widgetType);
         return;
       }
-      if ((msg as any).type === 'widget-move-up') {
-        void moveWidget((msg as any).widgetUid, (msg as any).area, 'up');
-        return;
-      }
-      if ((msg as any).type === 'widget-move-down') {
-        void moveWidget((msg as any).widgetUid, (msg as any).area, 'down');
+      if (
+        (msg as any).type === 'widget-move-up' ||
+        (msg as any).type === 'widget-move-down'
+      ) {
+        const direction =
+          (msg as any).type === 'widget-move-up' ? 'up' : 'down';
+        const targetSort = (msg as any).sortOrder;
+        if (typeof targetSort === 'number' && !Number.isNaN(targetSort)) {
+          // Iframe-computed target (layout-aware) — store it verbatim.
+          void moveWidgetTo((msg as any).widgetUid, (msg as any).area, targetSort);
+        } else {
+          // Older iframe bundle without move math — widget-neighbor swap.
+          void moveWidget((msg as any).widgetUid, (msg as any).area, direction);
+        }
         return;
       }
       if ((msg as any).type === 'widget-duplicate') {
@@ -2366,6 +2399,7 @@ export default function Editor({
     widgetTypes,
     drawerPinned,
     moveWidget,
+    moveWidgetTo,
     duplicateWidget
   ]);
 

--- a/tests/e2e/pageBuilder/specs/03-drag-drop/layout-component-drop.spec.ts
+++ b/tests/e2e/pageBuilder/specs/03-drag-drop/layout-component-drop.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test } from '@playwright/test';
+import {
+  countOperations,
+  getActiveChangesetId
+} from '../../../shared/changesetDb.js';
+import { loadAdminUserId } from '../../../shared/adminMeta.js';
+import { discardAdminChangesets, getDb } from '../../../shared/db.js';
+import { EditorPage } from '../../pages/EditorPage.js';
+import { PaletteTab } from '../../pages/PaletteTab.js';
+
+/**
+ * Drops relative to LAYOUT components (not widgets). `Area.tsx` renders an
+ * `AreaDropZone` after every renderable in an editable Area — widget
+ * instances AND layout components — so a widget can land between two layout
+ * components or below the last one. Before this, zones only existed at the
+ * area start and after existing widgets, which made a widget-less area like
+ * cart's `content` droppable in exactly one place (above the Breadcrumb).
+ *
+ * Fixture: the `cart` route. Its `content` area renders two layout
+ * components at code-defined sort orders — Breadcrumb (`sortOrder: 0`,
+ * `base/pages/frontStore/all/Breadcrumb.tsx`) and ShoppingCart
+ * (`sortOrder: 10`, `checkout/pages/frontStore/cart/ShoppingCart.tsx`) —
+ * and no widgets, so `computeDropSortOrder`'s results are exactly
+ * predictable: midpoint (0+10)/2 = 5 between them, prev+1 = 11 after the
+ * last one.
+ *
+ * Zone selectors lean on the DOM contract: each renderable's tagged wrapper
+ * (`data-evershop-pb-sort-order`) is immediately followed by its zone, so
+ * `[data-evershop-pb-sort-order="0"] + [data-evershop-pb-dropzone]` is "the
+ * seam right below Breadcrumb".
+ */
+
+const CONTENT = '[data-evershop-area-id="content"]';
+
+/**
+ * Drag a palette card onto the drop zone matched by `zoneSelector` inside
+ * the iframe. Mirrors `PaletteTab.dragToArea` (manual dragstart + drop with
+ * a shared DataTransfer — Playwright's `dragTo` doesn't reliably cross
+ * frames for HTML5 DnD) but takes an arbitrary zone selector instead of an
+ * area-start id.
+ */
+async function dropOnZone(
+  page: import('@playwright/test').Page,
+  args: { widgetLabel: string; widgetCode: string; zoneSelector: string }
+): Promise<void> {
+  await page.evaluate(
+    ({ widgetLabel, widgetCode, zoneSelector }) => {
+      const cards = Array.from(
+        document.querySelectorAll(
+          '.page-builder-editor aside button[draggable="true"]'
+        )
+      ) as HTMLButtonElement[];
+      const card = cards.find((c) =>
+        (c.textContent || '').trim().startsWith(widgetLabel)
+      );
+      if (!card) {
+        throw new Error(`Palette card "${widgetLabel}" not found.`);
+      }
+      const iframe = document.querySelector(
+        '.page-builder-editor iframe'
+      ) as HTMLIFrameElement | null;
+      if (!iframe?.contentDocument) {
+        throw new Error('Editor iframe missing.');
+      }
+      const zone = iframe.contentDocument.querySelector(
+        zoneSelector
+      ) as HTMLElement | null;
+      if (!zone) {
+        throw new Error(`Drop zone "${zoneSelector}" not found in iframe.`);
+      }
+      const dt = new DataTransfer();
+      dt.setData('application/x-evershop-widget', widgetCode);
+      dt.setData('text/plain', widgetCode);
+      card.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt
+        })
+      );
+      zone.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt
+        })
+      );
+    },
+    args
+  );
+}
+
+async function lastPlacementSortOrder(changesetId: number): Promise<number> {
+  const db = getDb();
+  const { rows } = await db.query<{ sort_order: number }>(
+    `SELECT (new_payload->>'sort_order')::float AS sort_order
+     FROM changeset_operation
+     WHERE changeset_id = $1
+       AND entity_urn LIKE 'urn:evershop:cms:widget_placement:%'
+       AND new_payload IS NOT NULL
+     ORDER BY change_order DESC LIMIT 1`,
+    [changesetId]
+  );
+  return rows[0].sort_order;
+}
+
+/**
+ * Open the cart editor and assert the fixture's shape (two layout wrappers
+ * at sort 0 / 10, no widgets in `content`). Returns the changeset id.
+ */
+async function openCartEditor(
+  page: import('@playwright/test').Page
+): Promise<number> {
+  const editor = new EditorPage(page);
+  const palette = new PaletteTab(page);
+  await editor.open('cart');
+  const changesetId = await getActiveChangesetId(loadAdminUserId());
+  expect(changesetId).not.toBeNull();
+
+  const frame = await editor.previewFrame();
+  await expect(
+    frame.locator(`${CONTENT} > [data-evershop-pb-sort-order="0"]`)
+  ).toBeAttached({ timeout: 10_000 });
+  await expect(
+    frame.locator(`${CONTENT} > [data-evershop-pb-sort-order="10"]`)
+  ).toBeAttached();
+  // Widgets placed in cart/content would offset the midpoint math — this
+  // spec's exact assertions assume the pristine two-layout-component shape.
+  await expect(
+    frame.locator(`${CONTENT} [data-evershop-pb-widget-uid]`)
+  ).toHaveCount(0);
+
+  await palette.ensureExpanded();
+  return changesetId!;
+}
+
+test.describe('drag-drop / layout components', () => {
+  test.beforeEach(async () => {
+    await discardAdminChangesets(loadAdminUserId());
+  });
+
+  test('drop between two layout components gets midpoint sort_order', async ({
+    page
+  }) => {
+    const changesetId = await openCartEditor(page);
+    const opsBefore = await countOperations(changesetId);
+
+    // The seam right below Breadcrumb (sort 0), right above ShoppingCart
+    // (sort 10).
+    await dropOnZone(page, {
+      widgetLabel: 'Text block',
+      widgetCode: 'text_block',
+      zoneSelector: `${CONTENT} > [data-evershop-pb-sort-order="0"] + [data-evershop-pb-dropzone]`
+    });
+
+    // 10s (vs the usual 5s): the two op POSTs are sequential and the dev
+    // server can be mid-rebuild when back-to-back editor sessions run.
+    await expect
+      .poll(() => countOperations(changesetId), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(opsBefore + 2);
+
+    expect(await lastPlacementSortOrder(changesetId)).toBe(5);
+  });
+
+  test('drop after the last layout component appends past it', async ({
+    page
+  }) => {
+    const changesetId = await openCartEditor(page);
+    const opsBefore = await countOperations(changesetId);
+
+    // The seam below ShoppingCart — the end of the content area. No next
+    // sibling carries a sort order, so the zone computes prev + 1.
+    await dropOnZone(page, {
+      widgetLabel: 'Text block',
+      widgetCode: 'text_block',
+      zoneSelector: `${CONTENT} > [data-evershop-pb-sort-order="10"] + [data-evershop-pb-dropzone]`
+    });
+
+    // 10s (vs the usual 5s): the two op POSTs are sequential and the dev
+    // server can be mid-rebuild when back-to-back editor sessions run.
+    await expect
+      .poll(() => countOperations(changesetId), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(opsBefore + 2);
+
+    expect(await lastPlacementSortOrder(changesetId)).toBe(11);
+  });
+});

--- a/tests/e2e/pageBuilder/specs/03-drag-drop/move-arrows.spec.ts
+++ b/tests/e2e/pageBuilder/specs/03-drag-drop/move-arrows.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test } from '@playwright/test';
+import { getActiveChangesetId } from '../../../shared/changesetDb.js';
+import { loadAdminUserId } from '../../../shared/adminMeta.js';
+import { discardAdminChangesets, getDb } from '../../../shared/db.js';
+import { EditorPage } from '../../pages/EditorPage.js';
+import { PaletteTab } from '../../pages/PaletteTab.js';
+
+/**
+ * Layout-aware Move arrows. The chrome's Move up / Move down buttons compute
+ * the target sort_order in the iframe (`computeMoveSortOrder` — walks the
+ * rendered sibling order, layout components included) and send it in the
+ * move message; the admin emits ONE UPDATE op with the value verbatim.
+ * Before this, `moveWidget` swapped sort values with the nearest WIDGET
+ * sibling only — a widget with no widget siblings had dead arrows, and
+ * moves teleported across layout components.
+ *
+ * Fixture: `cart` (Breadcrumb `sortOrder: 0`, ShoppingCart `sortOrder: 10`,
+ * no widgets — same deterministic shape as layout-component-drop.spec.ts).
+ * One linear walk covers every landing rule:
+ *
+ *   drop between them      → widget @ 5   (placement op #1)
+ *   Move up                → −1  = 0 − 1  (top of area; 1 op)
+ *   Move up again          → no-op        (already first; NO op, no message)
+ *   Move down              → 5   = (0+10)/2 (midpoint; 1 op)
+ *   Move down              → 11  = 10 + 1 (bottom of area; 1 op)
+ *   Move down again        → no-op        (already last; NO op)
+ *
+ * Exact PLACEMENT-op counts double as the single-op-per-move contract (the
+ * legacy swap emitted two). Instance ops are excluded — the drawer's
+ * mount-time settings normalization emits one at an unpredictable moment.
+ */
+
+const CONTENT = '[data-evershop-area-id="content"]';
+
+async function dropOnZone(
+  page: import('@playwright/test').Page,
+  args: { widgetLabel: string; widgetCode: string; zoneSelector: string }
+): Promise<void> {
+  await page.evaluate(
+    ({ widgetLabel, widgetCode, zoneSelector }) => {
+      const cards = Array.from(
+        document.querySelectorAll(
+          '.page-builder-editor aside button[draggable="true"]'
+        )
+      ) as HTMLButtonElement[];
+      const card = cards.find((c) =>
+        (c.textContent || '').trim().startsWith(widgetLabel)
+      );
+      if (!card) {
+        throw new Error(`Palette card "${widgetLabel}" not found.`);
+      }
+      const iframe = document.querySelector(
+        '.page-builder-editor iframe'
+      ) as HTMLIFrameElement | null;
+      if (!iframe?.contentDocument) {
+        throw new Error('Editor iframe missing.');
+      }
+      const zone = iframe.contentDocument.querySelector(
+        zoneSelector
+      ) as HTMLElement | null;
+      if (!zone) {
+        throw new Error(`Drop zone "${zoneSelector}" not found in iframe.`);
+      }
+      const dt = new DataTransfer();
+      dt.setData('application/x-evershop-widget', widgetCode);
+      dt.setData('text/plain', widgetCode);
+      card.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt
+        })
+      );
+      zone.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt
+        })
+      );
+    },
+    args
+  );
+}
+
+async function lastPlacementSortOrder(changesetId: number): Promise<number> {
+  const db = getDb();
+  const { rows } = await db.query<{ sort_order: number }>(
+    `SELECT (new_payload->>'sort_order')::float AS sort_order
+     FROM changeset_operation
+     WHERE changeset_id = $1
+       AND entity_urn LIKE 'urn:evershop:cms:widget_placement:%'
+       AND new_payload IS NOT NULL
+     ORDER BY change_order DESC LIMIT 1`,
+    [changesetId]
+  );
+  return rows[0].sort_order;
+}
+
+/**
+ * Count PLACEMENT ops only. The settings drawer auto-opens after a drop and
+ * its mount-time normalization can emit a `widget_instance` settings UPDATE
+ * op at an unpredictable moment — counting all ops races with it. Moves are
+ * placement UPDATEs, so this isolates exactly the ops under test (and the
+ * one-op-per-move contract stays asserted: each move bumps this by 1).
+ */
+async function countPlacementOps(changesetId: number): Promise<number> {
+  const db = getDb();
+  const { rows } = await db.query<{ n: string }>(
+    `SELECT COUNT(*) AS n
+     FROM changeset_operation
+     WHERE changeset_id = $1
+       AND entity_urn LIKE 'urn:evershop:cms:widget_placement:%'
+       AND new_payload IS NOT NULL`,
+    [changesetId]
+  );
+  return Number(rows[0].n);
+}
+
+test.describe('drag-drop / move arrows', () => {
+  test.beforeEach(async () => {
+    await discardAdminChangesets(loadAdminUserId());
+  });
+
+  test('arrows step over layout components with one UPDATE op per move', async ({
+    page
+  }) => {
+    // One editor session with five toolbar interactions, each gated on a
+    // preview round-trip — comfortably more than the default 30s budget on
+    // a dev-mode server that may be rebuilding.
+    test.setTimeout(120_000);
+    const editor = new EditorPage(page);
+    const palette = new PaletteTab(page);
+    await editor.open('cart');
+    const changesetId = await getActiveChangesetId(loadAdminUserId());
+    expect(changesetId).not.toBeNull();
+
+    const frame = await editor.previewFrame();
+    await expect(
+      frame.locator(`${CONTENT} > [data-evershop-pb-sort-order="0"]`)
+    ).toBeAttached({ timeout: 10_000 });
+    await expect(
+      frame.locator(`${CONTENT} [data-evershop-pb-widget-uid]`)
+    ).toHaveCount(0);
+    await palette.ensureExpanded();
+
+    // Seed: drop a Banner (renders a visible placeholder when unconfigured — a zero-height widget like an empty text block cannot be hovered for its toolbar) between Breadcrumb(0) and ShoppingCart(10).
+    await dropOnZone(page, {
+      widgetLabel: 'Banner',
+      widgetCode: 'banner',
+      zoneSelector: `${CONTENT} > [data-evershop-pb-sort-order="0"] + [data-evershop-pb-dropzone]`
+    });
+    await expect
+      .poll(() => countPlacementOps(changesetId!), { timeout: 10_000 })
+      .toBe(1);
+    const widget = frame.locator(`${CONTENT} [data-evershop-pb-widget-uid]`);
+    await expect(widget).toHaveAttribute(
+      'data-evershop-pb-sort-order',
+      '5',
+      { timeout: 10_000 }
+    );
+
+    // The drop auto-opens the settings drawer over the canvas' right edge,
+    // exactly where the chrome toolbar sits — it would intercept the arrow
+    // clicks. Close it; arrow clicks don't re-select, so it stays closed.
+    await page.getByRole('button', { name: 'Close settings' }).click();
+
+    const moveButton = (name: 'Move up' | 'Move down') =>
+      widget.getByRole('button', { name });
+
+    // Move up past Breadcrumb → top of area: 0 − 1 = −1. Exactly one op.
+    await widget.hover();
+    await moveButton('Move up').click();
+    await expect
+      .poll(() => countPlacementOps(changesetId!), { timeout: 10_000 })
+      .toBe(2);
+    expect(await lastPlacementSortOrder(changesetId!)).toBe(-1);
+    // The preview re-renders with the widget in its new slot — wait for it
+    // so the next move computes from the fresh sibling order.
+    await expect(widget).toHaveAttribute(
+      'data-evershop-pb-sort-order',
+      '-1',
+      { timeout: 20_000 }
+    );
+
+    // Move up again — already first: the iframe computes null and posts
+    // nothing. Give the (absent) message a moment, then assert no new op.
+    await widget.hover();
+    await moveButton('Move up').click();
+    await page.waitForTimeout(1_500);
+    expect(await countPlacementOps(changesetId!)).toBe(2);
+
+    // Move down past Breadcrumb → midpoint(0, 10) = 5.
+    await widget.hover();
+    await moveButton('Move down').click();
+    await expect
+      .poll(() => countPlacementOps(changesetId!), { timeout: 10_000 })
+      .toBe(3);
+    expect(await lastPlacementSortOrder(changesetId!)).toBe(5);
+    await expect(widget).toHaveAttribute('data-evershop-pb-sort-order', '5', {
+      timeout: 20_000
+    });
+
+    // Move down past ShoppingCart → bottom of area: 10 + 1 = 11.
+    await widget.hover();
+    await moveButton('Move down').click();
+    await expect
+      .poll(() => countPlacementOps(changesetId!), { timeout: 10_000 })
+      .toBe(4);
+    expect(await lastPlacementSortOrder(changesetId!)).toBe(11);
+    await expect(widget).toHaveAttribute('data-evershop-pb-sort-order', '11', {
+      timeout: 20_000
+    });
+
+    // Move down again — already last: no-op, no new op.
+    await widget.hover();
+    await moveButton('Move down').click();
+    await page.waitForTimeout(1_500);
+    expect(await countPlacementOps(changesetId!)).toBe(4);
+  });
+});


### PR DESCRIPTION
Drop zones existed only at area-start and after existing widgets, so a widget-less area (e.g. productView content: Breadcrumb + product) was droppable in exactly one place — above everything — and the toolbar arrows could only swap with widget neighbors, leaving a widget between layout components with dead arrows.

Area.tsx now owns every seam via a shared AreaDropZone (replaces AreaStartDropZone and WidgetChrome's inline zone): one at the area start and one after EVERY renderable — widget instances and layout components alike — in any editableInPageBuilder Area. Zones after wrappers that rendered null (homepage Breadcrumb) are collapsed by an :empty CSS rule so bands don't stack. No AreaProps or pb-drop message changes; production DOM unchanged.

Move up/down follow the same iframe-owns-the-math rule: WidgetChrome computes the target via computeMoveSortOrder (walks tagged siblings, skips null-rendering wrappers; midpoint between render-adjacent neighbors, ±1 at the edges, no-op when already first/last) and sends it in the move message; the Editor emits ONE placement UPDATE op verbatim (moveWidgetTo). The legacy widget-neighbor swap remains only as the fallback for move messages without a sortOrder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
