### PR TITLE
fix(stripe): bind PaymentIntent amount to the order

### DIFF
--- a/packages/evershop/src/modules/stripe/api/createPaymentIntent/createPaymentIntent.ts
+++ b/packages/evershop/src/modules/stripe/api/createPaymentIntent/createPaymentIntent.ts
@@ -1,12 +1,15 @@
 import { select } from '@evershop/postgres-query-builder';
 import Stripe from 'stripe';
-import smallestUnit from 'zero-decimal-currencies';
 import { pool } from '../../../../lib/postgres/connection.js';
 import { getConfig } from '../../../../lib/util/getConfig.js';
 import { OK, INVALID_PAYLOAD } from '../../../../lib/util/httpStatus.js';
 import { EvershopRequest } from '../../../../types/request.js';
 import { EvershopResponse } from '../../../../types/response.js';
 import { getSetting } from '../../../setting/services/setting.js';
+import {
+  cartOwnsOrder,
+  orderAmountInSmallestUnit
+} from '../../services/bindStripePayment.js';
 
 export default async (
   request: EvershopRequest,
@@ -29,6 +32,22 @@ export default async (
       }
     });
   } else {
+    const order = await select()
+      .from('order')
+      .where('uuid', '=', order_id)
+      .load(pool);
+
+    if (!order || !cartOwnsOrder(cart, order)) {
+      response.status(INVALID_PAYLOAD);
+      response.json({
+        error: {
+          status: INVALID_PAYLOAD,
+          message: 'Invalid order'
+        }
+      });
+      return;
+    }
+
     const stripeConfig = getConfig('system.stripe', {});
     let stripeSecretKey;
 
@@ -41,13 +60,13 @@ export default async (
 
     const stripe = new Stripe(stripeSecretKey);
 
-    // Create a PaymentIntent with the order amount and currency
+    // Charge the order total, not a client-chosen cart that may not own it.
     const paymentIntent = await stripe.paymentIntents.create({
-      amount: parseInt(smallestUnit(cart.grand_total, cart.currency), 10),
-      currency: cart.currency,
+      amount: orderAmountInSmallestUnit(order),
+      currency: order.currency,
       metadata: {
-        cart_id,
-        order_id
+        cart_id: cart.uuid,
+        order_id: order.uuid
       },
       automatic_payment_methods: {
         enabled: true

--- a/packages/evershop/src/modules/stripe/api/stripeWebHook/[bodyJson]webhook.ts
+++ b/packages/evershop/src/modules/stripe/api/stripeWebHook/[bodyJson]webhook.ts
@@ -16,6 +16,7 @@ import { EvershopResponse } from '../../../../types/response.js';
 import addOrderActivityLog from '../../../oms/services/addOrderActivityLog.js';
 import { updatePaymentStatus } from '../../../oms/services/updatePaymentStatus.js';
 import { getSetting } from '../../../setting/services/setting.js';
+import { stripeAmountMatchesOrder } from '../../services/bindStripePayment.js';
 
 export default async (
   request: EvershopRequest,
@@ -66,6 +67,11 @@ export default async (
       .load(connection);
     if (!order) {
       throw new Error(`Order with id ${order_id} not found`);
+    }
+    if (!stripeAmountMatchesOrder(paymentIntent, order)) {
+      throw new Error(
+        'Payment amount or currency does not match the order'
+      );
     }
     // Handle the event
     switch (event.type) {

--- a/packages/evershop/src/modules/stripe/services/bindStripePayment.ts
+++ b/packages/evershop/src/modules/stripe/services/bindStripePayment.ts
@@ -1,0 +1,35 @@
+import smallestUnit from 'zero-decimal-currencies';
+
+/**
+ * Public POST /stripe/paymentIntents accepts cart_id and order_id independently.
+ * The webhook later marks metadata.order_id paid. These helpers bind the
+ * PaymentIntent to the order that owns the cart and to that order's total.
+ */
+
+export function cartOwnsOrder(
+  cart: { cart_id: number | string },
+  order: { cart_id: number | string }
+): boolean {
+  return String(cart.cart_id) === String(order.cart_id);
+}
+
+export function orderAmountInSmallestUnit(order: {
+  grand_total: number | string;
+  currency: string;
+}): number {
+  return parseInt(smallestUnit(order.grand_total, order.currency), 10);
+}
+
+export function stripeAmountMatchesOrder(
+  paymentIntent: { amount: number; currency: string },
+  order: { grand_total: number | string; currency: string }
+): boolean {
+  if (!Number.isFinite(paymentIntent.amount)) {
+    return false;
+  }
+  return (
+    paymentIntent.amount === orderAmountInSmallestUnit(order) &&
+    String(paymentIntent.currency).toLowerCase() ===
+      String(order.currency).toLowerCase()
+  );
+}

--- a/packages/evershop/src/modules/stripe/tests/unit/bindStripePayment.test.js
+++ b/packages/evershop/src/modules/stripe/tests/unit/bindStripePayment.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  cartOwnsOrder,
+  orderAmountInSmallestUnit,
+  stripeAmountMatchesOrder
+} from '../../services/bindStripePayment.js';
+
+describe('cartOwnsOrder', () => {
+  it('accepts the cart that placed the order', () => {
+    expect(cartOwnsOrder({ cart_id: 41 }, { cart_id: 41 })).toBe(true);
+    expect(cartOwnsOrder({ cart_id: '41' }, { cart_id: 41 })).toBe(true);
+  });
+
+  it('rejects pairing a cheap cart with a different order', () => {
+    expect(cartOwnsOrder({ cart_id: 1 }, { cart_id: 99 })).toBe(false);
+  });
+});
+
+describe('stripeAmountMatchesOrder', () => {
+  const expensiveOrder = { grand_total: '500.00', currency: 'usd' };
+
+  it('accepts a PaymentIntent for the order total', () => {
+    const amount = orderAmountInSmallestUnit(expensiveOrder);
+    expect(amount).toBe(50000);
+    expect(
+      stripeAmountMatchesOrder({ amount, currency: 'usd' }, expensiveOrder)
+    ).toBe(true);
+    expect(
+      stripeAmountMatchesOrder({ amount, currency: 'USD' }, expensiveOrder)
+    ).toBe(true);
+  });
+
+  it('rejects a cheap PaymentIntent against an expensive order', () => {
+    const cheap = orderAmountInSmallestUnit({
+      grand_total: '1.00',
+      currency: 'usd'
+    });
+    expect(cheap).toBe(100);
+    expect(
+      stripeAmountMatchesOrder({ amount: cheap, currency: 'usd' }, expensiveOrder)
+    ).toBe(false);
+  });
+
+  it('rejects a currency mismatch at the same numeric amount', () => {
+    expect(
+      stripeAmountMatchesOrder({ amount: 50000, currency: 'eur' }, expensiveOrder)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`POST /stripe/paymentIntents` is public. It takes `cart_id` and `order_id` as independent fields, charges `cart.grand_total`, and writes `order_id` into PaymentIntent metadata. The webhook later marks that `metadata.order_id` paid after `constructEvent`.

A request that pairs a cheap cart with an expensive order UUID therefore charges the cheap total and still settles the expensive order. Stripe.tsx already sends both IDs from the same checkout. The server never checked they belong together.

Issue Number: N/A

## What is the new behavior?

Create-intent loads the order, requires `order.cart_id === cart.cart_id`, and charges `order.grand_total` / `order.currency`. Metadata uses the server-loaded UUIDs.

The webhook still uses `constructEvent`, then rejects a PaymentIntent whose amount or currency does not match the order.

Attacker already has network reach to the public create-intent route. They do not hold the Stripe webhook secret. Without the bind they only need one cheap cart UUID and one expensive pending order UUID.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Honest checkouts that send the cart that placed the order keep working. A mismatched cart/order pair now returns 400.

## Other information

Local: `npm test -- --testPathPattern=bindStripePayment` (5/5). Revert-tested: dropping the amount equality makes the cheap-intent case pass, which is the failure we want.

Drafted with Cursor, then I reviewed and ran the tests.


Made with [Cursor](https://cursor.com)