### PR TITLE
feat(cashback): add native cashback and rebate system (#966)

### DIFF
--- a/packages/evershop/src/bin/lib/loadModules.js
+++ b/packages/evershop/src/bin/lib/loadModules.js
@@ -85,6 +85,11 @@ const coreModules = [
     name: 'pageBuilder',
     resolve: path.resolve(__dirname, '../../modules/pageBuilder'),
     path: path.resolve(__dirname, '../../modules/pageBuilder')
+  },
+  {
+    name: 'cashback',
+    resolve: path.resolve(__dirname, '../../modules/cashback'),
+    path: path.resolve(__dirname, '../../modules/cashback')
   }
 ];
 

--- a/packages/evershop/src/modules/cashback/bootstrap.ts
+++ b/packages/evershop/src/modules/cashback/bootstrap.ts
@@ -1,0 +1,5 @@
+import { debug } from '../../lib/log/logger.js';
+
+export default async () => {
+  debug('[Cashback Module] Initialized successfully.');
+};

--- a/packages/evershop/src/modules/cashback/graphql/types/Cashback/Cashback.graphql
+++ b/packages/evershop/src/modules/cashback/graphql/types/Cashback/Cashback.graphql
@@ -1,0 +1,30 @@
+type CashbackTransaction {
+  uuid: String!
+  orderId: Int
+  amount: Float!
+  type: String!
+  status: String!
+  note: String
+  createdAt: String!
+}
+
+type CustomerCashbackBalance {
+  balance: Float!
+  pendingBalance: Float!
+  transactions: [CashbackTransaction]!
+}
+
+type CashbackSetting {
+  enabled: Boolean!
+  percentage: Float!
+  minOrderAmount: Float!
+}
+
+extend type Customer {
+  cashbackBalance: CustomerCashbackBalance
+}
+
+extend type Query {
+  cashbackSetting: CashbackSetting
+  customerCashback(customerId: Int): CustomerCashbackBalance
+}

--- a/packages/evershop/src/modules/cashback/graphql/types/Cashback/Cashback.resolvers.ts
+++ b/packages/evershop/src/modules/cashback/graphql/types/Cashback/Cashback.resolvers.ts
@@ -1,0 +1,61 @@
+import {
+  getCustomerBalance,
+  getCustomerTransactions
+} from '../../../services/customerBalanceService.js';
+import {
+  isCashbackEnabled,
+  getCashbackPercentage,
+  getCashbackMinOrderAmount
+} from '../../../services/cashbackSettings.js';
+
+export default {
+  Query: {
+    cashbackSetting: async () => ({
+      enabled: await isCashbackEnabled(),
+      percentage: await getCashbackPercentage(),
+      minOrderAmount: await getCashbackMinOrderAmount()
+    }),
+    customerCashback: async (root: any, { customerId }: { customerId?: number }, { customer }: any) => {
+      const id = customerId || customer?.customerId;
+      if (!id) {
+        return null;
+      }
+      const balance = await getCustomerBalance(id);
+      const transactions = await getCustomerTransactions(id);
+      return {
+        balance: balance.balance,
+        pendingBalance: balance.pending_balance,
+        transactions: transactions.map((t) => ({
+          uuid: t.uuid,
+          orderId: t.order_id,
+          amount: t.amount,
+          type: t.type,
+          status: t.status,
+          note: t.note,
+          createdAt: t.created_at
+        }))
+      };
+    }
+  },
+  Customer: {
+    cashbackBalance: async (customerObj: any) => {
+      const customerId = customerObj.customerId;
+      if (!customerId) return null;
+      const balance = await getCustomerBalance(customerId);
+      const transactions = await getCustomerTransactions(customerId);
+      return {
+        balance: balance.balance,
+        pendingBalance: balance.pending_balance,
+        transactions: transactions.map((t) => ({
+          uuid: t.uuid,
+          orderId: t.order_id,
+          amount: t.amount,
+          type: t.type,
+          status: t.status,
+          note: t.note,
+          createdAt: t.created_at
+        }))
+      };
+    }
+  }
+};

--- a/packages/evershop/src/modules/cashback/migration/Version-1.0.0.ts
+++ b/packages/evershop/src/modules/cashback/migration/Version-1.0.0.ts
@@ -1,0 +1,67 @@
+import { execute, type PoolClient } from '@evershop/postgres-query-builder';
+
+export default async (connection: PoolClient) => {
+  // Create customer_balance table
+  await execute(
+    connection,
+    `CREATE TABLE IF NOT EXISTS "customer_balance" (
+      "customer_balance_id" INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      "uuid" UUID NOT NULL DEFAULT gen_random_uuid (),
+      "customer_id" INT NOT NULL UNIQUE,
+      "balance" DECIMAL(12, 4) NOT NULL DEFAULT 0.0000,
+      "pending_balance" DECIMAL(12, 4) NOT NULL DEFAULT 0.0000,
+      "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+      "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "FK_CUSTOMER_BALANCE_CUSTOMER" FOREIGN KEY ("customer_id") REFERENCES "customer" ("customer_id") ON DELETE CASCADE
+    )`
+  );
+
+  await execute(
+    connection,
+    `CREATE INDEX IF NOT EXISTS "FK_CUSTOMER_BALANCE_CUSTOMER" ON "customer_balance" ("customer_id")`
+  );
+
+  // Create cashback_transaction table
+  await execute(
+    connection,
+    `CREATE TABLE IF NOT EXISTS "cashback_transaction" (
+      "cashback_transaction_id" INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      "uuid" UUID NOT NULL DEFAULT gen_random_uuid (),
+      "customer_id" INT NOT NULL,
+      "order_id" INT DEFAULT NULL,
+      "amount" DECIMAL(12, 4) NOT NULL,
+      "type" VARCHAR(32) NOT NULL, -- 'earned', 'redeemed', 'refunded', 'manual_adjustment'
+      "status" VARCHAR(32) NOT NULL DEFAULT 'available', -- 'pending', 'available', 'cancelled'
+      "note" TEXT DEFAULT NULL,
+      "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "FK_CASHBACK_TRANSACTION_CUSTOMER" FOREIGN KEY ("customer_id") REFERENCES "customer" ("customer_id") ON DELETE CASCADE
+    )`
+  );
+
+  await execute(
+    connection,
+    `CREATE INDEX IF NOT EXISTS "FK_CASHBACK_TRANSACTION_CUSTOMER" ON "cashback_transaction" ("customer_id")`
+  );
+
+  // Default cashback settings
+  await execute(
+    connection,
+    `INSERT INTO "setting" ("name", "value", "is_json")
+     VALUES ('cashback_enabled', '1', 0)
+     ON CONFLICT ("name") DO NOTHING`
+  );
+
+  await execute(
+    connection,
+    `INSERT INTO "setting" ("name", "value", "is_json")
+     VALUES ('cashback_percentage', '5', 0)
+     ON CONFLICT ("name") DO NOTHING`
+  );
+
+  await execute(
+    connection,
+    `INSERT INTO "setting" ("name", "value", "is_json")
+     VALUES ('cashback_min_order_amount', '0', 0)
+     ON CONFLICT ("name") DO NOTHING`
+  );
+};

--- a/packages/evershop/src/modules/cashback/pages/admin/all/CashbackSettingMenu.tsx
+++ b/packages/evershop/src/modules/cashback/pages/admin/all/CashbackSettingMenu.tsx
@@ -1,0 +1,30 @@
+import { SettingMenuItem } from '@components/admin/SettingMenuItem.js';
+import { _ } from '@evershop/evershop/lib/locale/translate/_';
+import React from 'react';
+
+interface CashbackSettingMenuProps {
+  cashbackSettingUrl: string;
+}
+
+export default function CashbackSettingMenu({
+  cashbackSettingUrl
+}: CashbackSettingMenuProps) {
+  return (
+    <SettingMenuItem
+      url={cashbackSettingUrl || '/setting/cashback'}
+      title={_('Cashback Setting')}
+      description={_('Manage customer rebate percentage and cashback rules')}
+    />
+  );
+}
+
+export const layout = {
+  areaId: 'settingPageMenu',
+  sortOrder: 45
+};
+
+export const query = `
+  query Query {
+    cashbackSettingUrl: url(routeId: "cashbackSetting")
+  }
+`;

--- a/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/CashbackSettingPage.tsx
+++ b/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/CashbackSettingPage.tsx
@@ -1,0 +1,134 @@
+import { SettingMenu } from '@components/admin/SettingMenu.js';
+import { Form } from '@components/common/form/Form.js';
+import { InputField } from '@components/common/form/InputField.js';
+import { ToggleField } from '@components/common/form/ToggleField.js';
+import { Button } from '@components/common/ui/Button.js';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from '@components/common/ui/Card.js';
+import { toast } from '@components/common/ui/Sonner.js';
+import { _ } from '@evershop/evershop/lib/locale/translate/_';
+import React from 'react';
+import { useQuery } from 'urql';
+
+const CASHBACK_SETTING_QUERY = `
+  query CashbackSettingAdminQuery {
+    cashbackSetting {
+      enabled
+      percentage
+      minOrderAmount
+    }
+  }
+`;
+
+export default function CashbackSettingPage() {
+  const [result] = useQuery({ query: CASHBACK_SETTING_QUERY });
+  const { data, fetching } = result;
+
+  const initialValues = {
+    cashback_enabled: data?.cashbackSetting?.enabled ? 1 : 0,
+    cashback_percentage: data?.cashbackSetting?.percentage ?? 5,
+    cashback_min_order_amount: data?.cashbackSetting?.minOrderAmount ?? 0
+  };
+
+  const handleSubmit = async (formData: any) => {
+    try {
+      const response = await fetch('/api/setting', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+      if (response.ok) {
+        toast.success(_('Cashback settings updated successfully!'));
+      } else {
+        toast.error(_('Failed to update settings.'));
+      }
+    } catch (e: any) {
+      toast.error(e?.message || _('Error saving cashback settings.'));
+    }
+  };
+
+  return (
+    <div className="flex gap-8">
+      <div className="w-1/4">
+        <SettingMenu active="cashback" />
+      </div>
+
+      <div className="w-3/4 space-y-6">
+        <Form
+          id="cashback-setting-form"
+          action="/api/setting"
+          method="POST"
+          isOmitContainer
+          onSuccess={() => toast.success(_('Cashback settings saved!'))}
+        >
+          <Card>
+            <CardHeader>
+              <CardTitle>{_('Cashback & Rebate Configuration')}</CardTitle>
+              <CardDescription>
+                {_('Configure automated cashback percentage earned by customers when placing orders.')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {fetching ? (
+                <div className="animate-pulse space-y-4">
+                  <div className="h-10 bg-muted rounded"></div>
+                  <div className="h-10 bg-muted rounded"></div>
+                </div>
+              ) : (
+                <>
+                  <ToggleField
+                    name="cashback_enabled"
+                    label={_('Enable Cashback Program')}
+                    description={_('When enabled, qualifying purchases credit customer accounts with cashback store balance.')}
+                    defaultValue={initialValues.cashback_enabled === 1}
+                  />
+
+                  <InputField
+                    name="cashback_percentage"
+                    label={_('Cashback Percentage (%)')}
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    max="100"
+                    placeholder="5.0"
+                    defaultValue={String(initialValues.cashback_percentage)}
+                    helperText={_('The percentage of order subtotal credited back as cashback.')}
+                  />
+
+                  <InputField
+                    name="cashback_min_order_amount"
+                    label={_('Minimum Order Subtotal ($)')}
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder="0.00"
+                    defaultValue={String(initialValues.cashback_min_order_amount)}
+                    helperText={_('Minimum subtotal required to qualify for cashback (set to 0 for no minimum).')}
+                  />
+                </>
+              )}
+            </CardContent>
+            <CardFooter className="flex justify-end border-t border-border pt-4">
+              <Button type="submit">
+                {_('Save Settings')}
+              </Button>
+            </CardFooter>
+          </Card>
+        </Form>
+      </div>
+    </div>
+  );
+}
+
+export const layout = {
+  areaId: 'content',
+  sortOrder: 10
+};

--- a/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/index.ts
+++ b/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/index.ts
@@ -1,0 +1,11 @@
+import { translate } from '../../../../../lib/locale/translate/translate.js';
+import { EvershopResponse } from '../../../../../types/response.js';
+import { setPageMetaInfo } from '../../../../cms/services/pageMetaInfo.js';
+
+export default (request: any, response: EvershopResponse, next: any) => {
+  setPageMetaInfo(request, {
+    title: translate('Cashback Settings'),
+    description: translate('Configure Cashback & Rebate settings')
+  });
+  next();
+};

--- a/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/route.json
+++ b/packages/evershop/src/modules/cashback/pages/admin/cashbackSetting/route.json
@@ -1,0 +1,5 @@
+{
+  "methods": ["GET"],
+  "path": "/setting/cashback",
+  "name": "Cashback Setting"
+}

--- a/packages/evershop/src/modules/cashback/pages/frontStore/account/CashbackWidget.tsx
+++ b/packages/evershop/src/modules/cashback/pages/frontStore/account/CashbackWidget.tsx
@@ -1,0 +1,54 @@
+import { _ } from '@evershop/evershop/lib/locale/translate/_';
+import React from 'react';
+import { useQuery } from 'urql';
+
+const CASHBACK_WIDGET_QUERY = `
+  query CashbackWidgetQuery {
+    currentCustomer {
+      cashbackBalance {
+        balance
+        pendingBalance
+      }
+    }
+  }
+`;
+
+export default function CashbackWidget() {
+  const [result] = useQuery({ query: CASHBACK_WIDGET_QUERY });
+  const { data } = result;
+
+  const balance = data?.currentCustomer?.cashbackBalance?.balance ?? 0;
+  const pendingBalance = data?.currentCustomer?.cashbackBalance?.pendingBalance ?? 0;
+
+  return (
+    <section className="account-cashback-widget py-6 border-t border-border mt-4">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="h5 flex items-center gap-2">
+          <span>🎁</span> {_('Cashback & Store Credit')}
+        </h2>
+        <a
+          href="/account/cashback"
+          className="text-sm font-medium text-emerald-600 hover:text-emerald-700 hover:underline"
+        >
+          {_('View details & history')} &rarr;
+        </a>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 rounded-xl border border-emerald-500/20 bg-gradient-to-r from-emerald-50/40 via-teal-50/20 to-background p-4">
+        <div>
+          <span className="text-xs text-muted-foreground block">{_('Available Credit')}</span>
+          <span className="text-xl font-bold text-emerald-600">${balance.toFixed(2)}</span>
+        </div>
+        <div>
+          <span className="text-xs text-muted-foreground block">{_('Pending Cashback')}</span>
+          <span className="text-xl font-bold text-amber-600">${pendingBalance.toFixed(2)}</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export const layout = {
+  areaId: 'accountPageAddressBook',
+  sortOrder: 20
+};

--- a/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/AccountCashbackPage.tsx
+++ b/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/AccountCashbackPage.tsx
@@ -1,0 +1,178 @@
+import { AccountHeader } from '@components/frontStore/customer/AccountHeader.js';
+import { _ } from '@evershop/evershop/lib/locale/translate/_';
+import React from 'react';
+import { useQuery } from 'urql';
+
+const CUSTOMER_CASHBACK_QUERY = `
+  query CustomerCashbackQuery {
+    currentCustomer {
+      customerId
+      fullName
+      cashbackBalance {
+        balance
+        pendingBalance
+        transactions {
+          uuid
+          orderId
+          amount
+          type
+          status
+          note
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export default function AccountCashbackPage() {
+  const [result] = useQuery({ query: CUSTOMER_CASHBACK_QUERY });
+  const { data, fetching, error } = result;
+
+  const cashbackData = data?.currentCustomer?.cashbackBalance;
+  const balance = cashbackData?.balance ?? 0;
+  const pendingBalance = cashbackData?.pendingBalance ?? 0;
+  const transactions = cashbackData?.transactions ?? [];
+
+  return (
+    <div className="account mx-auto max-w-3xl py-10 px-4">
+      <AccountHeader />
+
+      {/* Account Navigation Tabs */}
+      <nav className="account-nav sticky top-0 z-20 mb-6 border-b border-border bg-background">
+        <div className="flex items-center gap-6">
+          <a href="/account" className="border-b-2 border-transparent py-3 text-sm text-muted-foreground hover:text-foreground">
+            {_('Dashboard')}
+          </a>
+          <a href="/account/orders" className="border-b-2 border-transparent py-3 text-sm text-muted-foreground hover:text-foreground">
+            {_('Orders')}
+          </a>
+          <a href="/account/cashback" className="border-b-2 border-foreground font-medium py-3 text-sm text-foreground">
+            {_('Cashback & Rewards')}
+          </a>
+        </div>
+      </nav>
+
+      {/* Main Content Area */}
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold tracking-tight">{_('Cashback & Rewards')}</h2>
+          <span className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-inset ring-emerald-600/20">
+            {_('Active Rebate Program')}
+          </span>
+        </div>
+
+        {fetching ? (
+          <div className="animate-pulse space-y-4">
+            <div className="h-32 rounded-xl bg-muted/60"></div>
+            <div className="h-48 rounded-xl bg-muted/40"></div>
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+            {_('Failed to load cashback details. Please try again.')}
+          </div>
+        ) : (
+          <>
+            {/* Stat Cards */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="relative overflow-hidden rounded-xl border border-emerald-500/20 bg-gradient-to-br from-emerald-50/50 to-teal-50/30 p-6 shadow-sm dark:from-emerald-950/20 dark:to-teal-950/10">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-emerald-800 dark:text-emerald-300 uppercase tracking-wider">
+                    {_('Available Balance')}
+                  </span>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600">
+                    💰
+                  </div>
+                </div>
+                <div className="mt-3 text-3xl font-extrabold text-foreground">
+                  ${balance.toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {_('Can be applied as instant credit at checkout')}
+                </p>
+              </div>
+
+              <div className="relative overflow-hidden rounded-xl border border-amber-500/20 bg-gradient-to-br from-amber-50/50 to-orange-50/30 p-6 shadow-sm dark:from-amber-950/20 dark:to-orange-950/10">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-amber-800 dark:text-amber-300 uppercase tracking-wider">
+                    {_('Pending Balance')}
+                  </span>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
+                    ⏳
+                  </div>
+                </div>
+                <div className="mt-3 text-3xl font-extrabold text-foreground">
+                  ${pendingBalance.toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {_('Will be unlocked once recent orders are verified')}
+                </p>
+              </div>
+            </div>
+
+            {/* Transaction Ledger Table */}
+            <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+              <h3 className="text-lg font-semibold mb-4">{_('Transaction History')}</h3>
+              {transactions.length === 0 ? (
+                <div className="py-12 text-center text-muted-foreground">
+                  <p className="text-sm">{_('No cashback transactions yet.')}</p>
+                  <p className="mt-1 text-xs">{_('Earn cashback automatically when placing qualifying orders!')}</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-border text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        <th className="py-3 px-2">{_('Date')}</th>
+                        <th className="py-3 px-2">{_('Type')}</th>
+                        <th className="py-3 px-2">{_('Description / Order')}</th>
+                        <th className="py-3 px-2 text-right">{_('Amount')}</th>
+                        <th className="py-3 px-2 text-center">{_('Status')}</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {transactions.map((tx: any) => (
+                        <tr key={tx.uuid} className="hover:bg-muted/40 transition-colors">
+                          <td className="py-3.5 px-2 text-xs text-muted-foreground">
+                            {new Date(tx.createdAt).toLocaleDateString()}
+                          </td>
+                          <td className="py-3.5 px-2 font-medium capitalize text-xs">
+                            {tx.type.replace('_', ' ')}
+                          </td>
+                          <td className="py-3.5 px-2 text-xs">
+                            {tx.note || (tx.orderId ? `Order #${tx.orderId}` : '-')}
+                          </td>
+                          <td className={`py-3.5 px-2 text-right font-semibold text-xs ${
+                            tx.amount > 0 ? 'text-emerald-600' : 'text-rose-600'
+                          }`}>
+                            {tx.amount > 0 ? `+${tx.amount.toFixed(2)}` : tx.amount.toFixed(2)}
+                          </td>
+                          <td className="py-3.5 px-2 text-center">
+                            <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-semibold capitalize ${
+                              tx.status === 'available'
+                                ? 'bg-emerald-100 text-emerald-800'
+                                : tx.status === 'pending'
+                                ? 'bg-amber-100 text-amber-800'
+                                : 'bg-muted text-muted-foreground'
+                            }`}>
+                              {tx.status}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const layout = {
+  areaId: 'content',
+  sortOrder: 10
+};

--- a/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/index.ts
+++ b/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/index.ts
@@ -1,0 +1,20 @@
+import { translate } from '../../../../../lib/locale/translate/translate.js';
+import { buildUrl } from '../../../../../lib/router/buildUrl.js';
+import { EvershopResponse } from '../../../../../types/response.js';
+import { setPageMetaInfo } from '../../../../cms/services/pageMetaInfo.js';
+
+export default (request: any, response: EvershopResponse, next: any) => {
+  const isPageBuilderPreview =
+    typeof request.query?.changeset === 'string' &&
+    String(request.query.changeset).length > 0;
+
+  if (!isPageBuilderPreview && !request.isCustomerLoggedIn()) {
+    response.redirect(buildUrl('login'));
+  } else {
+    setPageMetaInfo(request, {
+      title: translate('My Cashback Balance'),
+      description: translate('View earned cashback balance and transactions')
+    });
+    next();
+  }
+};

--- a/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/route.json
+++ b/packages/evershop/src/modules/cashback/pages/frontStore/accountCashback/route.json
@@ -1,0 +1,6 @@
+{
+  "methods": ["GET"],
+  "path": "/account/cashback",
+  "name": "Account Cashback page",
+  "editable": true
+}

--- a/packages/evershop/src/modules/cashback/services/calculateOrderCashback.ts
+++ b/packages/evershop/src/modules/cashback/services/calculateOrderCashback.ts
@@ -1,0 +1,27 @@
+import {
+  isCashbackEnabled,
+  getCashbackPercentage,
+  getCashbackMinOrderAmount
+} from './cashbackSettings.js';
+
+export async function calculateOrderCashback(
+  orderSubtotal: number
+): Promise<number> {
+  const enabled = await isCashbackEnabled();
+  if (!enabled) {
+    return 0;
+  }
+
+  const minOrderAmount = await getCashbackMinOrderAmount();
+  if (orderSubtotal < minOrderAmount) {
+    return 0;
+  }
+
+  const percentage = await getCashbackPercentage();
+  if (percentage <= 0) {
+    return 0;
+  }
+
+  const cashback = (orderSubtotal * percentage) / 100;
+  return Math.round(cashback * 100) / 100;
+}

--- a/packages/evershop/src/modules/cashback/services/cashbackSettings.ts
+++ b/packages/evershop/src/modules/cashback/services/cashbackSettings.ts
@@ -1,0 +1,16 @@
+import { getSetting } from '../../setting/services/setting.js';
+
+export async function isCashbackEnabled(): Promise<boolean> {
+  const enabled = await getSetting('cashback_enabled', 1);
+  return parseInt(String(enabled), 10) === 1;
+}
+
+export async function getCashbackPercentage(): Promise<number> {
+  const percentage = await getSetting('cashback_percentage', 5);
+  return parseFloat(String(percentage)) || 0;
+}
+
+export async function getCashbackMinOrderAmount(): Promise<number> {
+  const minAmount = await getSetting('cashback_min_order_amount', 0);
+  return parseFloat(String(minAmount)) || 0;
+}

--- a/packages/evershop/src/modules/cashback/services/customerBalanceService.ts
+++ b/packages/evershop/src/modules/cashback/services/customerBalanceService.ts
@@ -1,0 +1,235 @@
+import { select, insert, update, execute } from '@evershop/postgres-query-builder';
+import { pool } from '../../../lib/postgres/connection.js';
+
+export interface CustomerBalance {
+  customer_balance_id: number;
+  uuid: string;
+  customer_id: number;
+  balance: number;
+  pending_balance: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CashbackTransaction {
+  cashback_transaction_id: number;
+  uuid: string;
+  customer_id: number;
+  order_id: number | null;
+  amount: number;
+  type: 'earned' | 'redeemed' | 'refunded' | 'manual_adjustment';
+  status: 'pending' | 'available' | 'cancelled';
+  note: string | null;
+  created_at: string;
+}
+
+/**
+ * Get or initialize customer balance record
+ */
+export async function getCustomerBalance(
+  customerId: number
+): Promise<CustomerBalance> {
+  let record = await select()
+    .from('customer_balance')
+    .where('customer_id', '=', customerId)
+    .load(pool);
+
+  if (!record) {
+    await execute(
+      pool,
+      `INSERT INTO "customer_balance" ("customer_id", "balance", "pending_balance")
+       VALUES (${customerId}, 0.0000, 0.0000)
+       ON CONFLICT ("customer_id") DO NOTHING`
+    );
+    record = await select()
+      .from('customer_balance')
+      .where('customer_id', '=', customerId)
+      .load(pool);
+  }
+
+  return {
+    customer_balance_id: record.customer_balance_id,
+    uuid: record.uuid,
+    customer_id: record.customer_id,
+    balance: parseFloat(record.balance) || 0,
+    pending_balance: parseFloat(record.pending_balance) || 0,
+    created_at: record.created_at,
+    updated_at: record.updated_at
+  };
+}
+
+/**
+ * Credit pending cashback when an order is placed
+ */
+export async function creditPendingCashback(
+  customerId: number,
+  orderId: number,
+  amount: number,
+  note: string = 'Order Cashback'
+): Promise<CashbackTransaction> {
+  await getCustomerBalance(customerId);
+
+  // Check if transaction already exists for this order & customer
+  const existing = await select()
+    .from('cashback_transaction')
+    .where('customer_id', '=', customerId)
+    .and('order_id', '=', orderId)
+    .and('type', '=', 'earned')
+    .load(pool);
+
+  if (existing) {
+    return existing;
+  }
+
+  // Insert transaction
+  const transaction = await insert('cashback_transaction')
+    .given({
+      customer_id: customerId,
+      order_id: orderId,
+      amount,
+      type: 'earned',
+      status: 'pending',
+      note
+    })
+    .execute(pool);
+
+  // Update pending balance
+  await execute(
+    pool,
+    `UPDATE "customer_balance"
+     SET "pending_balance" = "pending_balance" + ${amount},
+         "updated_at" = CURRENT_TIMESTAMP
+     WHERE "customer_id" = ${customerId}`
+  );
+
+  return transaction;
+}
+
+/**
+ * Activate pending cashback once order is paid/fulfilled
+ */
+export async function activatePendingCashback(
+  customerId: number,
+  orderId: number
+): Promise<void> {
+  const pendingTx = await select()
+    .from('cashback_transaction')
+    .where('customer_id', '=', customerId)
+    .and('order_id', '=', orderId)
+    .and('status', '=', 'pending')
+    .load(pool);
+
+  if (!pendingTx) {
+    return;
+  }
+
+  const amount = parseFloat(pendingTx.amount);
+
+  // Update transaction status
+  await update('cashback_transaction')
+    .given({ status: 'available' })
+    .where('cashback_transaction_id', '=', pendingTx.cashback_transaction_id)
+    .execute(pool);
+
+  // Move pending_balance -> balance
+  await execute(
+    pool,
+    `UPDATE "customer_balance"
+     SET "pending_balance" = GREATEST(0, "pending_balance" - ${amount}),
+         "balance" = "balance" + ${amount},
+         "updated_at" = CURRENT_TIMESTAMP
+     WHERE "customer_id" = ${customerId}`
+  );
+}
+
+/**
+ * Redeem cashback balance
+ */
+export async function redeemCashback(
+  customerId: number,
+  amount: number,
+  orderId?: number,
+  note: string = 'Redeemed at checkout'
+): Promise<boolean> {
+  const balanceRecord = await getCustomerBalance(customerId);
+  if (balanceRecord.balance < amount) {
+    return false;
+  }
+
+  await insert('cashback_transaction')
+    .given({
+      customer_id: customerId,
+      order_id: orderId ?? null,
+      amount: -Math.abs(amount),
+      type: 'redeemed',
+      status: 'available',
+      note
+    })
+    .execute(pool);
+
+  await execute(
+    pool,
+    `UPDATE "customer_balance"
+     SET "balance" = GREATEST(0, "balance" - ${Math.abs(amount)}),
+         "updated_at" = CURRENT_TIMESTAMP
+     WHERE "customer_id" = ${customerId}`
+  );
+
+  return true;
+}
+
+/**
+ * Manual balance adjustment by Admin
+ */
+export async function manualAdjustBalance(
+  customerId: number,
+  amount: number,
+  note: string = 'Admin manual adjustment'
+): Promise<void> {
+  await getCustomerBalance(customerId);
+
+  await insert('cashback_transaction')
+    .given({
+      customer_id: customerId,
+      amount,
+      type: 'manual_adjustment',
+      status: 'available',
+      note
+    })
+    .execute(pool);
+
+  await execute(
+    pool,
+    `UPDATE "customer_balance"
+     SET "balance" = GREATEST(0, "balance" + ${amount}),
+         "updated_at" = CURRENT_TIMESTAMP
+     WHERE "customer_id" = ${customerId}`
+  );
+}
+
+/**
+ * Get customer transaction ledger
+ */
+export async function getCustomerTransactions(
+  customerId: number,
+  limit: number = 50
+): Promise<CashbackTransaction[]> {
+  const items = await select()
+    .from('cashback_transaction')
+    .where('customer_id', '=', customerId)
+    .orderBy('cashback_transaction_id', 'DESC')
+    .limit(0, limit)
+    .execute(pool);
+
+  return (items || []).map((item: any) => ({
+    cashback_transaction_id: item.cashback_transaction_id,
+    uuid: item.uuid,
+    customer_id: item.customer_id,
+    order_id: item.order_id,
+    amount: parseFloat(item.amount),
+    type: item.type,
+    status: item.status,
+    note: item.note,
+    created_at: item.created_at
+  }));
+}

--- a/packages/evershop/src/modules/cashback/subscribers/order_placed/creditCashback.ts
+++ b/packages/evershop/src/modules/cashback/subscribers/order_placed/creditCashback.ts
@@ -1,0 +1,47 @@
+import { EventData } from '../../../../types/event.js';
+import { calculateOrderCashback } from '../../services/calculateOrderCashback.js';
+import {
+  creditPendingCashback,
+  activatePendingCashback
+} from '../../services/customerBalanceService.js';
+import { debug, error } from '../../../../lib/log/logger.js';
+
+export default async function creditCashback(
+  order: EventData<'order_placed'>
+) {
+  try {
+    if (!order || !order.customer_id) {
+      return;
+    }
+
+    const customerId = parseInt(String(order.customer_id), 10);
+    const orderId = parseInt(String(order.order_id), 10);
+    const subTotal = parseFloat(String(order.sub_total || order.grand_total || 0));
+
+    if (!customerId || !orderId || subTotal <= 0) {
+      return;
+    }
+
+    const cashbackAmount = await calculateOrderCashback(subTotal);
+    if (cashbackAmount > 0) {
+      await creditPendingCashback(
+        customerId,
+        orderId,
+        cashbackAmount,
+        `Cashback earned from order #${order.order_number || orderId}`
+      );
+      debug(`[Cashback] Credited $${cashbackAmount} pending cashback to customer #${customerId} for order #${orderId}`);
+
+      // If order payment status is already paid or COD, activate immediately
+      if (
+        order.payment_status === 'paid' ||
+        order.payment_method === 'cod'
+      ) {
+        await activatePendingCashback(customerId, orderId);
+        debug(`[Cashback] Activated $${cashbackAmount} cashback for order #${orderId}`);
+      }
+    }
+  } catch (err: any) {
+    error(`[Cashback Error] Failed to process order cashback: ${err?.message || err}`);
+  }
+}

--- a/packages/evershop/src/modules/cashback/tests/unit/calculateOrderCashback.test.ts
+++ b/packages/evershop/src/modules/cashback/tests/unit/calculateOrderCashback.test.ts
@@ -1,0 +1,46 @@
+import { calculateOrderCashback } from '../../services/calculateOrderCashback.js';
+import * as cashbackSettings from '../../services/cashbackSettings.js';
+
+jest.mock('../../services/cashbackSettings.js');
+
+describe('calculateOrderCashback unit tests', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns 0 if cashback program is disabled', async () => {
+    jest.spyOn(cashbackSettings, 'isCashbackEnabled').mockResolvedValue(false);
+    jest.spyOn(cashbackSettings, 'getCashbackPercentage').mockResolvedValue(10);
+    jest.spyOn(cashbackSettings, 'getCashbackMinOrderAmount').mockResolvedValue(0);
+
+    const result = await calculateOrderCashback(100);
+    expect(result).toBe(0);
+  });
+
+  test('returns 0 if subtotal is less than min order amount threshold', async () => {
+    jest.spyOn(cashbackSettings, 'isCashbackEnabled').mockResolvedValue(true);
+    jest.spyOn(cashbackSettings, 'getCashbackPercentage').mockResolvedValue(5);
+    jest.spyOn(cashbackSettings, 'getCashbackMinOrderAmount').mockResolvedValue(50);
+
+    const result = await calculateOrderCashback(30);
+    expect(result).toBe(0);
+  });
+
+  test('calculates correct cashback percentage when subtotal exceeds threshold', async () => {
+    jest.spyOn(cashbackSettings, 'isCashbackEnabled').mockResolvedValue(true);
+    jest.spyOn(cashbackSettings, 'getCashbackPercentage').mockResolvedValue(10);
+    jest.spyOn(cashbackSettings, 'getCashbackMinOrderAmount').mockResolvedValue(20);
+
+    const result = await calculateOrderCashback(150);
+    expect(result).toBe(15);
+  });
+
+  test('rounds cashback amount to 2 decimal places', async () => {
+    jest.spyOn(cashbackSettings, 'isCashbackEnabled').mockResolvedValue(true);
+    jest.spyOn(cashbackSettings, 'getCashbackPercentage').mockResolvedValue(7.5);
+    jest.spyOn(cashbackSettings, 'getCashbackMinOrderAmount').mockResolvedValue(0);
+
+    const result = await calculateOrderCashback(33.33);
+    expect(result).toBe(2.5);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

Issue Number: #966

## What is the new behavior?

- Added a native `cashback` core module under `packages/evershop/src/modules/cashback`.
- Added database tables `customer_balance` and `cashback_transaction` with automatic seed settings.
- Added `creditCashback` subscriber listening to `order_placed` events to award rebates automatically to customer accounts.
- Added GraphQL queries & resolvers for customer cashback balance, transaction history, and settings.
- Built storefront customer account dashboard at `/account/cashback` and dashboard widget on `/account`.
- Built admin settings UI at `/setting/cashback` to configure cashback percentage and minimum order threshold.
- Added unit tests for cashback calculation service logic.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
