### PR TITLE
fix(oms): stop prefixing the base URL onto absolute thumbnail URLs

### DIFF
--- a/packages/evershop/src/modules/oms/services/thumbnailUrl.ts
+++ b/packages/evershop/src/modules/oms/services/thumbnailUrl.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve an order-item thumbnail for use in transactional emails.
+ *
+ * Local file storage stores thumbnails as site-relative paths
+ * (`/assets/catalog/...`), which need the store's base URL prefixed to
+ * survive an email client. Remote storage providers (S3, Cloudinary, …)
+ * store the full URL already — prefixing those produces a broken
+ * double-URL src (`https://store.comhttps://bucket.s3...`).
+ */
+export function resolveThumbnailUrl(thumbnail: string, baseUrl: string): string {
+  return /^https?:\/\//i.test(thumbnail) ? thumbnail : `${baseUrl}${thumbnail}`;
+}

--- a/packages/evershop/src/modules/oms/subscribers/order_placed/sendOrderConfirmationEmail.ts
+++ b/packages/evershop/src/modules/oms/subscribers/order_placed/sendOrderConfirmationEmail.ts
@@ -16,6 +16,7 @@ import { getConfig } from '../../../../lib/util/getConfig.js';
 import { getValue } from '../../../../lib/util/registry.js';
 import { EventData } from '../../../../types/event.js';
 import { getStoreLanguage } from '../../../setting/services/setting.js';
+import { resolveThumbnailUrl } from '../../services/thumbnailUrl.js';
 
 const TEMPLATE = `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html dir="ltr" lang="en">
@@ -648,11 +649,11 @@ export default async function sendOrderConfirmationEmail(
       .from('order_item')
       .where('order_item_order_id', '=', order.order_id)
       .execute(pool);
-    // Loop through each item to add the base Url before the thumbnail path
+    // Local storage stores thumbnails as relative paths; remote providers
+    // store absolute URLs that must pass through untouched.
     order.items = items.map((item) => {
       if (item.thumbnail) {
-        const baseUrl = getBaseUrl();
-        item.thumbnail = `${baseUrl}${item.thumbnail}`;
+        item.thumbnail = resolveThumbnailUrl(item.thumbnail, getBaseUrl());
       }
       return item;
     });

--- a/packages/evershop/src/modules/oms/tests/unit/thumbnailUrl.test.js
+++ b/packages/evershop/src/modules/oms/tests/unit/thumbnailUrl.test.js
@@ -1,0 +1,34 @@
+import { resolveThumbnailUrl } from '../../services/thumbnailUrl.js';
+
+/**
+ * Regression for the double-URL thumbnail in the order-confirmation email.
+ * The subscriber prefixed the base URL onto EVERY thumbnail; with a remote
+ * storage provider (S3, Cloudinary, …) the stored value is already an
+ * absolute URL, so the email rendered
+ * `https://store.example.comhttps://bucket.s3.../thermos-black.jpg` — a 404
+ * in every inbox. Relative paths (local storage) still need the prefix.
+ */
+describe('resolveThumbnailUrl', () => {
+  const BASE = 'https://lucky-summit-4901.myevershop.io';
+
+  it('prefixes the base URL onto relative local-storage paths', () => {
+    expect(resolveThumbnailUrl('/assets/catalog/9424/1250/thermos.jpg', BASE)).toBe(
+      'https://lucky-summit-4901.myevershop.io/assets/catalog/9424/1250/thermos.jpg'
+    );
+  });
+
+  it('passes absolute URLs through untouched (remote storage providers)', () => {
+    const s3 =
+      'https://evershop-stage0-site-54da42ce.s3.ap-southeast-1.amazonaws.com/catalog/9424/1250/thermos-black.jpg';
+    expect(resolveThumbnailUrl(s3, BASE)).toBe(s3);
+  });
+
+  it('treats scheme matching as case-insensitive and covers plain http', () => {
+    expect(resolveThumbnailUrl('HTTP://cdn.example.com/x.jpg', BASE)).toBe(
+      'HTTP://cdn.example.com/x.jpg'
+    );
+    expect(resolveThumbnailUrl('http://cdn.example.com/x.jpg', BASE)).toBe(
+      'http://cdn.example.com/x.jpg'
+    );
+  });
+});


### PR DESCRIPTION
The order-confirmation email prefixed getBaseUrl() onto every order_item.thumbnail — correct for local storage (relative /assets/… paths) but wrong for remote storage providers (S3, Cloudinary, …) whose stored value is already an absolute URL: the email rendered `https://store.example.comhttps://bucket.s3….jpg`, a 404 thumbnail in every inbox.

resolveThumbnailUrl passes absolute URLs through untouched and still prefixes relative paths; the subscriber uses it, and the regression is pinned by a unit test. Shipment emails carry no thumbnails — this was the only affected sender.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
