### PR TITLE
fix(session): guard auth middlewares on session-exempt asset routes

### DIFF
--- a/packages/evershop/src/modules/auth/pages/admin/all/[context]auth.js
+++ b/packages/evershop/src/modules/auth/pages/admin/all/[context]auth.js
@@ -3,6 +3,14 @@ import { pool } from '../../../../../lib/postgres/connection.js';
 import { buildUrl } from '../../../../../lib/router/buildUrl.js';
 
 export default async (request, response, next) => {
+  // Asset-serving routes (adminStaticAsset) are exempt from session (see
+  // bin/lib/routeNeedsSession.ts), so request.session is undefined there. No
+  // session means no logged-in user to resolve — bail out cleanly instead of
+  // destructuring undefined.
+  if (!request.session) {
+    next();
+    return;
+  }
   const { userID } = request.session;
   // Load the user from the database
   const user = await select()

--- a/packages/evershop/src/modules/customer/pages/frontStore/all/[context]auth.js
+++ b/packages/evershop/src/modules/customer/pages/frontStore/all/[context]auth.js
@@ -3,6 +3,14 @@ import { pool } from '../../../../../lib/postgres/connection.js';
 import { buildUrl } from '../../../../../lib/router/buildUrl.js';
 
 export default async (request, response, next) => {
+  // Asset-serving routes (the /images optimizer, static assets) are exempt
+  // from session (see bin/lib/routeNeedsSession.ts), so request.session is
+  // undefined there. No session means no logged-in customer to resolve — bail
+  // out cleanly instead of destructuring undefined.
+  if (!request.session) {
+    next();
+    return;
+  }
   const { customerID } = request.session;
   if (!customerID) {
     delete request.locals.customer;


### PR DESCRIPTION
Commit 2d12dcc6 exempted the images/staticAsset/adminStaticAsset routes from session, but the frontStore/all customer-auth and admin/all admin-auth middlewares still destructured request.session on every route. Any storefront image or static-asset request therefore threw "Cannot destructure property 'customerID' of 'request.session' as it is undefined".

Bail out with next() when request.session is undefined — on a session-exempt asset route there is no logged-in customer/admin to resolve.


Claude-Session: https://claude.ai/code/session_01CqeaSDuah9HYP6jd16HSKD

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
