### PR TITLE
fix(stripe): bind charge amount to the order and harden the webhook

### DIFF
--- a/packages/evershop/src/modules/stripe/api/createPaymentIntent/createPaymentIntent.ts
+++ b/packages/evershop/src/modules/stripe/api/createPaymentIntent/createPaymentIntent.ts
@@ -1,53 +1,67 @@
 import { select } from '@evershop/postgres-query-builder';
 import Stripe from 'stripe';
-import smallestUnit from 'zero-decimal-currencies';
+import { error } from '../../../../lib/log/logger.js';
 import { pool } from '../../../../lib/postgres/connection.js';
 import { getConfig } from '../../../../lib/util/getConfig.js';
-import { OK, INVALID_PAYLOAD } from '../../../../lib/util/httpStatus.js';
+import {
+  INTERNAL_SERVER_ERROR,
+  INVALID_PAYLOAD,
+  OK
+} from '../../../../lib/util/httpStatus.js';
 import { EvershopRequest } from '../../../../types/request.js';
 import { EvershopResponse } from '../../../../types/response.js';
 import { getSetting } from '../../../setting/services/setting.js';
+import { toStripeMinorUnit } from '../../services/stripeAmount.js';
 
 export default async (
   request: EvershopRequest,
   response: EvershopResponse,
   next
 ) => {
-  const { cart_id, order_id } = request.body;
-  // Check the cart
-  const cart = await select()
-    .from('cart')
-    .where('uuid', '=', cart_id)
-    .load(pool);
+  try {
+    const { order_id } = request.body;
 
-  if (!cart) {
-    response.status(INVALID_PAYLOAD);
-    response.json({
-      error: {
-        status: INVALID_PAYLOAD,
-        message: 'Invalid cart'
-      }
-    });
-  } else {
-    const stripeConfig = getConfig('system.stripe', {});
-    let stripeSecretKey;
+    // The charge amount MUST come from the order, never from a client-supplied
+    // cart. The order is the frozen, server-owned record of what is owed; a
+    // request that pairs a cheap cart with an expensive order can no longer mint
+    // a cheap intent. Scoped to a pending Stripe order so an already-paid or
+    // foreign order cannot be re-charged or under-charged.
+    const order = await select()
+      .from('order')
+      .where('uuid', '=', order_id)
+      .and('payment_method', '=', 'stripe')
+      .and('payment_status', '=', 'pending')
+      .load(pool);
 
-    if (stripeConfig?.secretKey) {
-      stripeSecretKey = stripeConfig.secretKey;
-    } else {
-      stripeSecretKey = await getSetting('stripeSecretKey', '');
+    if (!order) {
+      response.status(INVALID_PAYLOAD);
+      response.json({
+        error: {
+          status: INVALID_PAYLOAD,
+          message: 'Invalid order'
+        }
+      });
+      return;
     }
+
+    const stripeConfig = getConfig('system.stripe', {}) as {
+      secretKey?: string;
+    };
+    const stripeSecretKey = stripeConfig?.secretKey
+      ? stripeConfig.secretKey
+      : await getSetting('stripeSecretKey', '');
     const stripePaymentMode = await getSetting('stripePaymentMode', 'capture');
 
     const stripe = new Stripe(stripeSecretKey);
 
-    // Create a PaymentIntent with the order amount and currency
+    // The metadata order_id is what the webhook and the return page bind the
+    // intent back to. It is the order's own uuid, set here — not echoed from
+    // the client — so the binding is trustworthy.
     const paymentIntent = await stripe.paymentIntents.create({
-      amount: parseInt(smallestUnit(cart.grand_total, cart.currency), 10),
-      currency: cart.currency,
+      amount: toStripeMinorUnit(order.grand_total, order.currency),
+      currency: order.currency,
       metadata: {
-        cart_id,
-        order_id
+        order_id: order.uuid
       },
       automatic_payment_methods: {
         enabled: true
@@ -60,6 +74,15 @@ export default async (
     response.json({
       data: {
         clientSecret: paymentIntent.client_secret
+      }
+    });
+  } catch (err) {
+    error(err);
+    response.status(INTERNAL_SERVER_ERROR);
+    response.json({
+      error: {
+        status: INTERNAL_SERVER_ERROR,
+        message: 'Can not create the payment intent'
       }
     });
   }

--- a/packages/evershop/src/modules/stripe/api/refundPaymentIntent/refundPaymentIntent.ts
+++ b/packages/evershop/src/modules/stripe/api/refundPaymentIntent/refundPaymentIntent.ts
@@ -20,16 +20,16 @@ import { updatePaymentStatus } from '../../../oms/services/updatePaymentStatus.j
 import { getSetting } from '../../../setting/services/setting.js';
 
 export default async (request, response, next) => {
-  const connection = await getConnection(pool);
   try {
-    await startTransaction(connection);
-
     const { order_id, amount } = request.body;
-    // Load the order
+
+    // Read-only validation on the shared pool, BEFORE acquiring a dedicated
+    // connection. The old code opened a transaction first and returned early on
+    // these guards without rolling back, leaking the pooled client every time.
     const order = await select()
       .from('order')
       .where('order_id', '=', order_id)
-      .load(connection);
+      .load(pool);
     if (!order || order.payment_method !== 'stripe') {
       response.status(INVALID_PAYLOAD);
       response.json({
@@ -41,11 +41,20 @@ export default async (request, response, next) => {
       return;
     }
 
-    // Get the payment transaction
-    const paymentTransaction = await select()
+    // Pick the latest transaction deterministically (an order can carry more
+    // than one row — e.g. a re-payment). For a single Stripe PaymentIntent the
+    // authorize and capture share the same transaction_id, so this is one row
+    // in the common case. `.orderBy` lives on the query, not on the `Where`
+    // node, so hold the handle and set the clauses on it separately.
+    const paymentTransactionQuery = select()
       .from('payment_transaction')
-      .where('payment_transaction_order_id', '=', order.order_id)
-      .load(connection);
+      .orderBy('payment_transaction_id', 'DESC');
+    paymentTransactionQuery.where(
+      'payment_transaction_order_id',
+      '=',
+      order.order_id
+    );
+    const paymentTransaction = await paymentTransactionQuery.load(pool);
     if (!paymentTransaction) {
       response.status(INVALID_PAYLOAD);
       response.json({
@@ -58,15 +67,12 @@ export default async (request, response, next) => {
     }
 
     const stripeConfig = getConfig('system.stripe', {});
-    let stripeSecretKey;
-
-    if (stripeConfig?.secretKey) {
-      stripeSecretKey = stripeConfig.secretKey;
-    } else {
-      stripeSecretKey = await getSetting('stripeSecretKey', '');
-    }
+    const stripeSecretKey = stripeConfig?.secretKey
+      ? stripeConfig.secretKey
+      : await getSetting('stripeSecretKey', '');
     const stripe = new Stripe(stripeSecretKey);
-    // Refund
+
+    // Refund at Stripe first (a network call — kept out of the DB transaction).
     const refund = await stripe.refunds.create({
       payment_intent: paymentTransaction.transaction_id,
       amount: parseInt(smallestUnit(amount, order.currency), 10)
@@ -76,19 +82,27 @@ export default async (request, response, next) => {
         ? refund.charge
         : refund.charge?.id ?? '';
     const charge = await stripe.charges.retrieve(chargeId);
-    // Update the order status
     const status =
       charge.refunded === true ? 'stripe_refunded' : 'stripe_partial_refunded';
-    await updatePaymentStatus(order.order_id, status, connection);
 
-    // Add order activity log
-    await addOrderActivityLog(
-      order.order_id,
-      `Refunded ${amount} ${charge.currency}`,
-      false,
-      connection
-    );
-    await commit(connection);
+    // Short transaction for the DB writes only. getConnection immediately
+    // followed by startTransaction — no pre-tx reads on this client.
+    const connection = await getConnection(pool);
+    try {
+      await startTransaction(connection);
+      await updatePaymentStatus(order.order_id, status, connection);
+      await addOrderActivityLog(
+        order.order_id,
+        `Refunded ${amount} ${charge.currency}`,
+        false,
+        connection
+      );
+      await commit(connection);
+    } catch (dbErr) {
+      await rollback(connection);
+      throw dbErr;
+    }
+
     response.status(OK);
     response.json({
       data: {
@@ -97,7 +111,6 @@ export default async (request, response, next) => {
     });
   } catch (err) {
     error(err);
-    await rollback(connection);
     response.status(INTERNAL_SERVER_ERROR);
     response.json({
       error: {

--- a/packages/evershop/src/modules/stripe/api/stripeWebHook/[bodyJson]webhook.ts
+++ b/packages/evershop/src/modules/stripe/api/stripeWebHook/[bodyJson]webhook.ts
@@ -2,8 +2,8 @@ import {
   startTransaction,
   commit,
   rollback,
-  select,
-  insertOnUpdate
+  insertOnUpdate,
+  PoolClient
 } from '@evershop/postgres-query-builder';
 import stripePgk from 'stripe';
 import { display } from 'zero-decimal-currencies';
@@ -16,6 +16,47 @@ import { EvershopResponse } from '../../../../types/response.js';
 import addOrderActivityLog from '../../../oms/services/addOrderActivityLog.js';
 import { updatePaymentStatus } from '../../../oms/services/updatePaymentStatus.js';
 import { getSetting } from '../../../setting/services/setting.js';
+import { paymentIntentMatchesOrder } from '../../services/stripeAmount.js';
+
+/**
+ * Load the order row with `FOR UPDATE` so it stays locked for the life of the
+ * webhook transaction. Stripe can deliver the same event twice (a retry can
+ * overlap a slow original); without the lock both deliveries read "no
+ * transaction yet" and both emit `order_placed` — duplicate confirmation email
+ * and duplicate side effects. The lock serializes them: the second delivery
+ * blocks until the first commits, then sees the transaction row and stops.
+ */
+async function loadOrderByUuidForUpdate(
+  connection: PoolClient,
+  uuid: string | undefined
+) {
+  if (!uuid) {
+    return undefined;
+  }
+  const { rows } = await connection.query(
+    'SELECT * FROM "order" WHERE "uuid" = $1 FOR UPDATE',
+    [uuid]
+  );
+  return rows[0];
+}
+
+async function loadOrderByPaymentIntentForUpdate(
+  connection: PoolClient,
+  paymentIntentId: string | undefined
+) {
+  if (!paymentIntentId) {
+    return undefined;
+  }
+  const { rows } = await connection.query(
+    `SELECT o.* FROM "order" o
+       JOIN "payment_transaction" pt
+         ON pt."payment_transaction_order_id" = o."order_id"
+      WHERE pt."transaction_id" = $1
+      FOR UPDATE OF o`,
+    [paymentIntentId]
+  );
+  return rows[0];
+}
 
 export default async (
   request: EvershopRequest,
@@ -31,48 +72,118 @@ export default async (
       secretKey?: string;
       endpointSecret?: string;
     };
-    let stripeSecretKey;
-    if (stripeConfig.secretKey) {
-      stripeSecretKey = stripeConfig.secretKey;
-    } else {
-      stripeSecretKey = await getSetting('stripeSecretKey', '');
-    }
+    const stripeSecretKey = stripeConfig.secretKey
+      ? stripeConfig.secretKey
+      : await getSetting('stripeSecretKey', '');
     const stripe = new stripePgk(stripeSecretKey);
 
-    // Webhook enpoint secret
-    let endpointSecret;
-    if (stripeConfig.endpointSecret) {
-      endpointSecret = stripeConfig.endpointSecret;
-    } else {
-      endpointSecret = await getSetting('stripeEndpointSecret', '');
-    }
+    // Webhook endpoint secret
+    const endpointSecret = stripeConfig.endpointSecret
+      ? stripeConfig.endpointSecret
+      : await getSetting('stripeEndpointSecret', '');
 
     event = stripe.webhooks.constructEvent(
       request.body,
       sig as string,
       endpointSecret
     );
+
     await startTransaction(connection);
-    const paymentIntent = event.data.object as stripePgk.PaymentIntent;
-    const { order_id } = paymentIntent.metadata;
-    const transaction = await select()
-      .from('payment_transaction')
-      .where('transaction_id', '=', paymentIntent.id)
-      .load(connection);
-    // Load the order
-    const order = await select()
-      .from('order')
-      .where('uuid', '=', order_id)
-      .load(connection);
-    if (!order) {
-      throw new Error(`Order with id ${order_id} not found`);
+
+    // ---- Refund events (money-out, e.g. issued from the Stripe Dashboard) ----
+    // EverShop-initiated refunds already set the status in their own request;
+    // this reflects refunds made outside EverShop. Idempotent and consistent
+    // with the admin flow: it only acts when the status actually changes.
+    if (event.type === 'charge.refunded') {
+      const charge = event.data.object as stripePgk.Charge;
+      const paymentIntentId =
+        typeof charge.payment_intent === 'string'
+          ? charge.payment_intent
+          : charge.payment_intent?.id;
+      const order = await loadOrderByPaymentIntentForUpdate(
+        connection,
+        paymentIntentId
+      );
+      if (order && order.payment_method === 'stripe') {
+        const desired = charge.refunded
+          ? 'stripe_refunded'
+          : 'stripe_partial_refunded';
+        if (
+          order.payment_status !== desired &&
+          ['stripe_captured', 'stripe_partial_refunded'].includes(
+            order.payment_status
+          )
+        ) {
+          await updatePaymentStatus(order.order_id, desired, connection);
+          await addOrderActivityLog(
+            order.order_id,
+            `Refund of ${display(
+              charge.amount_refunded,
+              charge.currency
+            )} ${String(charge.currency).toUpperCase()} recorded from Stripe. Charge ID: ${charge.id}`,
+            false,
+            connection
+          );
+        }
+      }
+      await commit(connection);
+      response.json({ received: true });
+      return;
     }
+
+    // ---- PaymentIntent events (money-in) ----
+    const paymentIntent = event.data.object as stripePgk.PaymentIntent;
+    const order = await loadOrderByUuidForUpdate(
+      connection,
+      paymentIntent.metadata?.order_id
+    );
+    if (!order) {
+      throw new Error(
+        `Order with id ${paymentIntent.metadata?.order_id} not found`
+      );
+    }
+
+    // Reject any money-in intent that does not match this order in amount +
+    // currency, or that is not a Stripe order. This is the server-side close of
+    // the amount-integrity hole: the order owns the amount, the intent must
+    // agree with it before we mark anything paid.
+    const isMoneyInEvent =
+      event.type === 'payment_intent.succeeded' ||
+      event.type === 'payment_intent.amount_capturable_updated';
+    if (isMoneyInEvent) {
+      if (order.payment_method !== 'stripe') {
+        debug(`Ignoring Stripe webhook for non-Stripe order ${order.order_id}`);
+        await commit(connection);
+        response.json({ received: true });
+        return;
+      }
+      if (!paymentIntentMatchesOrder(order, paymentIntent)) {
+        error(
+          new Error(
+            `Stripe amount mismatch for order ${order.order_id}: intent ${paymentIntent.id} charged ${paymentIntent.amount} ${paymentIntent.currency}, order expects ${order.grand_total} ${order.currency}. Not marking as paid.`
+          )
+        );
+        // Acknowledge so Stripe stops retrying (a mismatch is terminal, not
+        // transient); nothing is written, so the order is held at `pending` for
+        // manual review rather than auto-fulfilled.
+        await commit(connection);
+        response.json({ received: true });
+        return;
+      }
+    }
+
+    // Whether this is the first time we process this intent, decided under the
+    // row lock so concurrent deliveries cannot both see "not processed".
+    const { rows: existingTxn } = await connection.query(
+      'SELECT 1 FROM "payment_transaction" WHERE "transaction_id" = $1 AND "payment_transaction_order_id" = $2',
+      [paymentIntent.id, order.order_id]
+    );
+    const alreadyProcessed = existingTxn.length > 0;
+
     // Handle the event
     switch (event.type) {
       case 'payment_intent.succeeded': {
         debug('payment_intent.succeeded event received');
-        // Update the order
-        // Create payment transaction
         await insertOnUpdate('payment_transaction', [
           'transaction_id',
           'payment_transaction_order_id'
@@ -89,29 +200,30 @@ export default async (
           })
           .execute(connection);
 
-        if (!transaction) {
+        if (!alreadyProcessed) {
           await updatePaymentStatus(
             order.order_id,
             'stripe_captured',
             connection
           );
-
-          // Add an activity log
           await addOrderActivityLog(
             order.order_id,
             `Payment captured by using Stripe. Transaction ID: ${paymentIntent.id}`,
             false,
             connection
           );
-
-          // Emit event to add order placed event
-          await emit('order_placed', { ...order });
+          // Emit on THIS connection so the event insert lives or dies with the
+          // status update and only becomes visible to subscribers after commit.
+          await emit(
+            'order_placed',
+            { ...order, payment_status: 'stripe_captured' },
+            connection
+          );
         }
         break;
       }
       case 'payment_intent.amount_capturable_updated': {
         debug('payment_intent.amount_capturable_updated event received');
-        // Create payment transaction
         await insertOnUpdate('payment_transaction', [
           'transaction_id',
           'payment_transaction_order_id'
@@ -130,27 +242,50 @@ export default async (
           })
           .execute(connection);
 
-        if (!transaction) {
+        if (!alreadyProcessed) {
           await updatePaymentStatus(
             order.order_id,
             'stripe_authorized',
             connection
           );
-          // Add an activity log
           await addOrderActivityLog(
             order.order_id,
             `Payment authorized by using Stripe. Transaction ID: ${paymentIntent.id}`,
             false,
             connection
           );
-          // Emit event to add order placed event
-          await emit('order_placed', { ...order });
+          await emit(
+            'order_placed',
+            { ...order, payment_status: 'stripe_authorized' },
+            connection
+          );
+        }
+        break;
+      }
+      case 'payment_intent.payment_failed': {
+        debug('payment_intent.payment_failed event received');
+        // Delayed-notification methods (and any post-return failure) settle
+        // here. Without this the order would sit at `pending` forever. Only
+        // touch a still-pending order so a captured/authorized one is never
+        // overridden by a late failure event.
+        if (order.payment_status === 'pending') {
+          await updatePaymentStatus(order.order_id, 'stripe_failed', connection);
+          const reason =
+            paymentIntent.last_payment_error?.message || 'Payment failed.';
+          await addOrderActivityLog(
+            order.order_id,
+            `Stripe payment failed. ${reason} Transaction ID: ${paymentIntent.id}`,
+            false,
+            connection
+          );
         }
         break;
       }
       case 'payment_intent.canceled': {
         debug('payment_intent.canceled event received');
-        await updatePaymentStatus(order.order_id, 'canceled', connection);
+        if (order.payment_status !== 'canceled') {
+          await updatePaymentStatus(order.order_id, 'canceled', connection);
+        }
         break;
       }
       default: {

--- a/packages/evershop/src/modules/stripe/pages/frontStore/stripeReturn/index.ts
+++ b/packages/evershop/src/modules/stripe/pages/frontStore/stripeReturn/index.ts
@@ -1,4 +1,5 @@
 import { select, update } from '@evershop/postgres-query-builder';
+import { NextFunction } from 'express';
 import Stripe from 'stripe';
 import { error } from '../../../../../lib/log/logger.js';
 import { pool } from '../../../../../lib/postgres/connection.js';
@@ -9,11 +10,12 @@ import { updatePaymentStatus } from '../../../../../modules/oms/services/updateP
 import { getSetting } from '../../../../../modules/setting/services/setting.js';
 import { EvershopRequest } from '../../../../../types/request.js';
 import { EvershopResponse } from '../../../../../types/response.js';
+import { resolveStripeReturnOutcome } from '../../../services/returnOutcome.js';
 
 export default async (
   request: EvershopRequest,
   response: EvershopResponse,
-  next
+  next: NextFunction
 ) => {
   try {
     const { order_id, payment_intent } = request.query;
@@ -27,51 +29,55 @@ export default async (
       .where('uuid', '=', order_id)
       .load(pool);
 
-    if (!order) {
-      // Redirect to the home page
+    if (!order || order.payment_method !== 'stripe') {
       response.redirect(buildUrl('homepage'));
       return;
     }
 
     const stripeConfig = getConfig('system.stripe', {});
-    let stripeSecretKey;
-    if (stripeConfig?.secretKey) {
-      stripeSecretKey = stripeConfig.secretKey;
-    } else {
-      stripeSecretKey = await getSetting('stripeSecretKey', '');
-    }
-    const stripePaymentMode = await getSetting('stripePaymentMode', 'capture');
+    const stripeSecretKey = stripeConfig?.secretKey
+      ? stripeConfig.secretKey
+      : await getSetting('stripeSecretKey', '');
     const stripe = new Stripe(stripeSecretKey, {} as Stripe.StripeConfig);
     const paymentIntent = await stripe.paymentIntents.retrieve(payment_intent);
-    // Check if the payment intent is succeeded
-    if (
-      (stripePaymentMode === 'capture' &&
-        paymentIntent.status === 'succeeded') ||
-      (stripePaymentMode === 'authorizeOnly' &&
-        paymentIntent.status === 'requires_capture')
-    ) {
-      // Redirect to the order success page
-      response.redirect(buildUrl('checkoutSuccess', { orderId: order_id }));
-      return;
-    } else {
-      // Redirect back to the shopping cart
-      // Active the cart
-      await update('cart')
-        .given({ status: true })
-        .where('cart_id', '=', order.cart_id)
-        .execute(pool);
-      await updatePaymentStatus(order.order_id, 'stripe_failed');
-      // Add a error notification
-      addNotification(request, 'Payment failed', 'error');
-      request.session.save(() => {
-        // Redirect to the shopping cart
-        response.redirect(buildUrl('cart'));
-      });
+
+    // Bind the intent to this order. The return URL is public and both query
+    // params are attacker-controllable; without this check a foreign or
+    // cheaper order's intent id could drive a redirect or a status change on
+    // someone else's order. The metadata order_id is set server-side in
+    // createPaymentIntent, so it is trustworthy.
+    if (!paymentIntent || paymentIntent.metadata?.order_id !== order_id) {
+      response.redirect(buildUrl('homepage'));
       return;
     }
+
+    const outcome = resolveStripeReturnOutcome(paymentIntent.status);
+    if (outcome === 'success' || outcome === 'pending') {
+      // `pending` = a delayed-notification method still settling. The order is
+      // real and the webhook finalizes it, so send the buyer to the order
+      // page rather than marking it failed and reactivating the cart.
+      response.redirect(buildUrl('checkoutSuccess', { orderId: order_id }));
+      return;
+    }
+
+    // Genuine dead end: re-activate the cart so the buyer can retry.
+    await update('cart')
+      .given({ status: true })
+      .where('cart_id', '=', order.cart_id)
+      .execute(pool);
+    // Only fail a still-pending order — the browser return can race a webhook
+    // that already captured/authorized it, and that must not be clobbered.
+    if (order.payment_status === 'pending') {
+      await updatePaymentStatus(order.order_id, 'stripe_failed');
+    }
+    // Add an error notification
+    addNotification(request, 'Payment failed', 'error');
+    request.session.save(() => {
+      // Redirect to the shopping cart
+      response.redirect(buildUrl('cart'));
+    });
   } catch (e) {
     error(e);
     response.redirect(buildUrl('homepage'));
-    return;
   }
 };

--- a/packages/evershop/src/modules/stripe/services/returnOutcome.ts
+++ b/packages/evershop/src/modules/stripe/services/returnOutcome.ts
@@ -1,0 +1,28 @@
+export type StripeReturnOutcome = 'success' | 'pending' | 'failure';
+
+/**
+ * Maps a PaymentIntent status seen at the `/stripe/return` redirect to what the
+ * storefront should do next.
+ *
+ * - `succeeded` / `requires_capture` — the money is secured (captured or
+ *   authorized). Send the buyer to the order success page.
+ * - `processing` — a delayed-notification method (some wallets, bank debits)
+ *   still settling. This is NOT a failure; the webhook finalizes it. Marking it
+ *   failed and dumping the buyer back to the cart (the old behavior) was wrong.
+ * - anything else (`requires_payment_method`, `requires_action`, `canceled`, …)
+ *   is a genuine dead end → back to the cart to retry.
+ *
+ * Intentionally independent of the capture/authorize setting: both `succeeded`
+ * and `requires_capture` mean the buyer's part is done, and the webhook maps
+ * each to the correct EverShop status regardless of the current mode (which can
+ * change mid-flight).
+ */
+export function resolveStripeReturnOutcome(status: string): StripeReturnOutcome {
+  if (status === 'succeeded' || status === 'requires_capture') {
+    return 'success';
+  }
+  if (status === 'processing') {
+    return 'pending';
+  }
+  return 'failure';
+}

--- a/packages/evershop/src/modules/stripe/services/stripeAmount.ts
+++ b/packages/evershop/src/modules/stripe/services/stripeAmount.ts
@@ -1,0 +1,29 @@
+import smallestUnit from 'zero-decimal-currencies';
+
+/**
+ * An amount expressed in the currency's smallest unit — the integer Stripe
+ * charges in. `10.00 USD` → `1000`, `1000 JPY` → `1000` (zero-decimal). Stripe's
+ * `PaymentIntent.amount` is always a minor-unit integer.
+ */
+export function toStripeMinorUnit(amount: number | string, currency: string): number {
+  return parseInt(smallestUnit(amount, currency), 10);
+}
+
+/**
+ * True when a PaymentIntent's charged amount and currency match the order it is
+ * about to be applied to. The order is the authoritative, server-owned record of
+ * what is owed; the webhook trusts nothing until this holds. Closes the
+ * "pay for a cheap cart, apply the intent to an expensive order" hole — the
+ * charge amount and the order it settles are bound together, not taken on faith
+ * from client-supplied ids.
+ */
+export function paymentIntentMatchesOrder(
+  order: { grand_total: number | string; currency: string },
+  paymentIntent: { amount: number; currency: string }
+): boolean {
+  return (
+    paymentIntent.amount === toStripeMinorUnit(order.grand_total, order.currency) &&
+    String(paymentIntent.currency).toLowerCase() ===
+      String(order.currency).toLowerCase()
+  );
+}

--- a/packages/evershop/src/modules/stripe/tests/unit/returnOutcome.test.js
+++ b/packages/evershop/src/modules/stripe/tests/unit/returnOutcome.test.js
@@ -1,0 +1,20 @@
+import { resolveStripeReturnOutcome } from '../../services/returnOutcome.js';
+
+describe('resolveStripeReturnOutcome', () => {
+  it('treats a captured or authorized intent as success', () => {
+    expect(resolveStripeReturnOutcome('succeeded')).toBe('success');
+    expect(resolveStripeReturnOutcome('requires_capture')).toBe('success');
+  });
+
+  it('treats a still-processing async payment as pending, not failure', () => {
+    // The regression this guards: `processing` used to be marked stripe_failed
+    // and the cart reactivated, even though the webhook would later succeed.
+    expect(resolveStripeReturnOutcome('processing')).toBe('pending');
+  });
+
+  it('treats a genuine dead-end status as failure', () => {
+    expect(resolveStripeReturnOutcome('requires_payment_method')).toBe('failure');
+    expect(resolveStripeReturnOutcome('requires_action')).toBe('failure');
+    expect(resolveStripeReturnOutcome('canceled')).toBe('failure');
+  });
+});

--- a/packages/evershop/src/modules/stripe/tests/unit/stripeAmount.test.js
+++ b/packages/evershop/src/modules/stripe/tests/unit/stripeAmount.test.js
@@ -1,0 +1,50 @@
+import {
+  paymentIntentMatchesOrder,
+  toStripeMinorUnit
+} from '../../services/stripeAmount.js';
+
+describe('toStripeMinorUnit', () => {
+  it('converts major units to minor for two-decimal currencies', () => {
+    expect(toStripeMinorUnit(10, 'USD')).toBe(1000);
+    expect(toStripeMinorUnit(10.5, 'USD')).toBe(1050);
+    expect(toStripeMinorUnit(10.99, 'EUR')).toBe(1099);
+  });
+
+  it('accepts the decimal-as-string values the pg driver returns', () => {
+    expect(toStripeMinorUnit('500.0000', 'USD')).toBe(50000);
+  });
+
+  it('keeps zero-decimal currencies whole', () => {
+    expect(toStripeMinorUnit(1000, 'JPY')).toBe(1000);
+  });
+});
+
+describe('paymentIntentMatchesOrder', () => {
+  it('accepts an exact amount + currency match (currency case-insensitive)', () => {
+    expect(
+      paymentIntentMatchesOrder(
+        { grand_total: 25, currency: 'USD' },
+        { amount: 2500, currency: 'usd' }
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an underpaid amount — the order-hijack vector', () => {
+    // $500 order, intent only charged $5.00 (500 minor units).
+    expect(
+      paymentIntentMatchesOrder(
+        { grand_total: 500, currency: 'USD' },
+        { amount: 500, currency: 'usd' }
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a currency mismatch even when the number matches', () => {
+    expect(
+      paymentIntentMatchesOrder(
+        { grand_total: 25, currency: 'USD' },
+        { amount: 2500, currency: 'eur' }
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
- createPaymentIntent derives amount/currency from the order, not a client cart
- webhook verifies amount+currency, locks the order row, emits transactionally
- handle payment_intent.payment_failed and charge.refunded
- stripeReturn binds the intent to the order; processing is pending, not failure
- fix a connection leak in refundPaymentIntent; add unit tests

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
