### PR TITLE
fix(paypal): resolve tsc build errors in refund and create-order

### DIFF
--- a/packages/evershop/src/modules/paypal/api/paypalCreateOrder/[bodyParser]createOrder.ts
+++ b/packages/evershop/src/modules/paypal/api/paypalCreateOrder/[bodyParser]createOrder.ts
@@ -121,7 +121,7 @@ export default async (
         };
       } else {
         (
-          orderData.payment_source.paypal as any
+          orderData.payment_source!.paypal as any
         ).experience_context.shipping_preference = 'NO_SHIPPING';
       }
       const finalPaypalOrderData = getValueSync<CreateOrderRequestBody>(

--- a/packages/evershop/src/modules/paypal/services/paypalRefund.ts
+++ b/packages/evershop/src/modules/paypal/services/paypalRefund.ts
@@ -70,13 +70,16 @@ export async function recordPaypalRefund(
 
     // The capture being refunded — by id when the caller knows it, otherwise
     // the order's capture transaction.
-    let captureQuery = select()
+    const captureQuery = select()
       .from('payment_transaction')
       .where('payment_transaction_order_id', '=', order.order_id);
+    // `.and()` mutates the where clause in place and returns a `Node`, which
+    // lacks `Where`'s `andWhere`/`orWhere` — so reassigning the `Where` handle
+    // does not type-check. Call `.and()` for its side effect and keep the handle.
     if (captureId) {
-      captureQuery = captureQuery.and('transaction_id', '=', captureId);
+      captureQuery.and('transaction_id', '=', captureId);
     } else {
-      captureQuery = captureQuery.and('payment_action', '=', 'capture');
+      captureQuery.and('payment_action', '=', 'capture');
     }
     const capture = await captureQuery.load(connection);
     if (!capture) {


### PR DESCRIPTION
The PayPal hardening code compiled under swc (which strips types) but failed a tsc build with three type errors:

- paypalRefund.ts reassigned a Where query handle to .and()'s Node return; .and() mutates in place, so drop the reassignment and keep the handle (which has .load()). - paypalCreateOrder.ts dereferenced the optional payment_source, which is always constructed above, so assert non-null.

Type-only; no runtime behavior change. Full package now type-checks clean.


Claude-Session: https://claude.ai/code/session_01CqeaSDuah9HYP6jd16HSKD

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
