### PR TITLE
docs(stripe): list required webhook events in the settings help text

### DIFF
--- a/packages/evershop/src/modules/stripe/pages/admin/paymentSetting/StripePayment.tsx
+++ b/packages/evershop/src/modules/stripe/pages/admin/paymentSetting/StripePayment.tsx
@@ -107,7 +107,7 @@ export default function StripePayment({
               placeholder={_('Secret Key')}
               defaultValue={stripeEndpointSecret || ''}
               helperText={_(
-                'Your webhook url should be: https://yourdomain.com/api/stripe/webhook'
+                'Your webhook URL should be: https://yourdomain.com/api/stripe/webhook. Enable these events (or "All events"): payment_intent.succeeded, payment_intent.amount_capturable_updated, payment_intent.payment_failed, payment_intent.canceled, charge.refunded.'
               )}
             />
           </div>


### PR DESCRIPTION
The webhook now handles five events (payment_intent.succeeded, amount_capturable_updated, payment_failed, canceled, and charge.refunded), but the settings help text told merchants only the URL. Spell out the events to enable so the payment-failed and Dashboard-refund handlers actually fire.


Claude-Session: https://claude.ai/code/session_01CqeaSDuah9HYP6jd16HSKD

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
