### PR TITLE
fix(setting): skip cache warm-up during `evershop build` (no DB attac…

### DIFF
--- a/packages/evershop/src/modules/setting/bootstrap.ts
+++ b/packages/evershop/src/modules/setting/bootstrap.ts
@@ -1,7 +1,17 @@
 import { debug, error } from '../../lib/log/logger.js';
 import { refreshSetting } from './services/setting.js';
 
-export default async () => {
+export default async (context: { command?: string } = {}) => {
+  // `evershop build` compiles the app with the module bootstraps loaded but NO
+  // database attached, so warming the setting cache here can only fail with
+  // ECONNREFUSED — which is not the fresh-install 42P01 handled below, so it
+  // would take the loud error() path and make every build log look like a crash
+  // (seen in the IS-04 stack builds). The cache is a runtime concern; there is
+  // nothing to warm at build time.
+  if (context.command === 'build') {
+    return;
+  }
+
   // Warm the in-memory setting cache so the synchronous accessors (`getSettingSync` and the
   // `*Sync` getters) are reliable from the first request onward — the pricing formatter,
   // email Handlebars helpers and metafield schema builders all read settings synchronously.

--- a/packages/evershop/src/modules/setting/tests/unit/bootstrap.test.ts
+++ b/packages/evershop/src/modules/setting/tests/unit/bootstrap.test.ts
@@ -73,4 +73,12 @@ describe('setting bootstrap (cache warm-up)', () => {
 
     expect(error).toHaveBeenCalledTimes(1);
   });
+
+  it('skips the warm-up entirely during `evershop build` (no DB attached)', async () => {
+    await expect(bootstrap({ command: 'build' })).resolves.toBeUndefined();
+
+    expect(refreshSetting).not.toHaveBeenCalled();
+    expect(debug).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
…hed)

The setting bootstrap warms the cache via refreshSetting(), which opens a Postgres connection. `evershop build` loads the module bootstraps to compile the app but has no database, so the warm-up threw AggregateError [ECONNREFUSED] — and since that is not the fresh-install 42P01 case, it took the loud error() path and made every build (notably the IS-04 stack builds) log a full stack trace that looks like a crash.

The build command already passes command:'build' in the bootstrap context; skip the warm-up when it is set. Runtime paths are unchanged — a real DB outage at runtime still logs loudly. Test asserts refreshSetting is not called on build.


Claude-Session: https://claude.ai/code/session_01V4sVtzW8Yn6JJ4BMPEhcUd

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
