### PR TITLE
fix(graphql): buildQuery must not hang when NODE_ENV is neither dev n…

### DIFF
--- a/packages/evershop/src/modules/graphql/pages/global/[bodyParser,notFound]buildQuery[graphql].js
+++ b/packages/evershop/src/modules/graphql/pages/global/[bodyParser,notFound]buildQuery[graphql].js
@@ -8,7 +8,6 @@ import { error } from '../../../../lib/log/logger.js';
 import { getRoutes } from '../../../../lib/router/Router.js';
 import { get } from '../../../../lib/util/get.js';
 import isDevelopmentMode from '../../../../lib/util/isDevelopmentMode.js';
-import isProductionMode from '../../../../lib/util/isProductionMode.js';
 import { getRouteBuildPath } from '../../../../lib/webpack/getRouteBuildPath.js';
 import { getEnabledWidgets } from '../../../../lib/widget/widgetManager.js';
 import { loadWidgetInstances } from '../../../cms/services/widget/loadWidgetInstances.js';
@@ -38,7 +37,14 @@ export default async (request, response, next) => {
 
       const queryPath = path.resolve(outputPath, `query-${route.id}.graphql`);
       query = outputFileSystem.readFileSync(queryPath, 'utf8');
-    } else if (isProductionMode()) {
+      // Not development → read the compiled query. Previously guarded on
+      // isProductionMode(), which left a gap: any NODE_ENV that is neither
+      // 'development' nor 'production' (a test/e2e runner, or unset) matched
+      // neither branch, so `query` stayed undefined and `next()` below (only
+      // reached inside `if (query)`) never ran — the request hung. The two real
+      // modes are the webpack dev server or a compiled build, so treat anything
+      // that is not development as the build.
+    } else {
       const routes = getRoutes();
       const route = request.currentRoute;
       const subPath = getRouteBuildPath(route);
@@ -329,6 +335,6 @@ export default async (request, response, next) => {
     }
   } catch (e) {
     error(e);
-    throw error;
+    throw e;
   }
 };


### PR DESCRIPTION
…or production

The page-query middleware read the compiled GraphQL query in one of two branches — isDevelopmentMode() (webpack dev middleware) or isProductionMode() (BUILDPATH) — with no else. Both helpers are strict NODE_ENV equality, so any other value (a test/e2e runner, or unset) matched neither branch: query stayed undefined, and next() — which only runs inside `if (query)` — was never called, so the request hung until it timed out. evershop start/build/dev set NODE_ENV correctly, so this only bit non-standard starts, but a hung request with no error is the worst failure mode.

Treat anything that is not 'development' as the compiled build (the two real modes are the dev server or a build), and fix the catch that re-threw the imported `error` logger instead of the caught exception.


Claude-Session: https://claude.ai/code/session_01V4sVtzW8Yn6JJ4BMPEhcUd

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
